### PR TITLE
Add prestop lifecycle to handle better node termination

### DIFF
--- a/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
+++ b/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       serviceAccountName: {{ include "webhook-broker-chart.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
+++ b/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
             - name: http
               containerPort: {{ .Values.broker.port }}
               protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 30"]
           volumeMounts:
             - name: conf-vol
               mountPath: /app-config/

--- a/deploy-pkg/webhook-broker-chart/values.yaml
+++ b/deploy-pkg/webhook-broker-chart/values.yaml
@@ -14,6 +14,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+terminationGracePeriodSeconds: 300
+
 broker:
   configFileWatchMode: "stop" # Possible values stop, restart, ignore
   port: 8080
@@ -35,19 +37,19 @@ broker:
   initSeedData: |
     [initial-channels]
     sample-channel=Sample Channel
-    
+
     [initial-producers]
     sample-producer=Sample Producer
-    
+
     [initial-consumers]
     sample-consumer=http://sample-endpoint/webhook-receiver
-    
+
     [initial-channel-tokens]
     sample-channel=sample-channel-token
-    
+
     [initial-producer-tokens]
     sample-producer=sample-producer-token
-    
+
     [sample-consumer]
     token=sample-consumer-token
     channel=sample-channel
@@ -63,10 +65,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -80,7 +84,8 @@ service:
 
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
## Why

To add a pre-stop lifecycle to ensure pod termination is handled better when nodes are being scaled down, this will reduce the number of 5xx errors when scaling down or an instance refresh is done for k8s updates

## How 

* Add a `lifecyle` hook