### PR TITLE
SKYNET-2952: Upgrade ingress api version from v1beta to v1

### DIFF
--- a/deploy-pkg/webhook-broker-chart/templates/ingress.yaml
+++ b/deploy-pkg/webhook-broker-chart/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "webhook-broker-chart.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Ingress v1beta api version is removed in kubernetes 1.22. So we need to update it to v1 version before upgrading the cluster.