### PR TITLE
SKYNET-2967: Add annotations to security group policy manifest

### DIFF
--- a/deploy-pkg/webhook-broker-chart/templates/securitygrouppolicy.yaml
+++ b/deploy-pkg/webhook-broker-chart/templates/securitygrouppolicy.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "webhook-broker-chart.name" . }}
   labels:
     {{- include "webhook-broker-chart.labels" . | nindent 4 }}
+  {{- with .Values.securityGroupPolicyAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/deploy-pkg/webhook-broker-chart/values.yaml
+++ b/deploy-pkg/webhook-broker-chart/values.yaml
@@ -13,6 +13,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+securityGroupPolicyAnnotations: {}
 
 useEksSecurityGroupForPods: false
 securityGroups: []


### PR DESCRIPTION
We want to add pre-install hook annotations to security group policy manifests. But adding them to existing namespaces removes the security groups so we can't hardcode the annotations in the charts. This PR adds annotations from values so that we can pass them while deploying to new namespaces.