### PR TITLE
AR-314: Duplicate priority column from message table into job table

### DIFF
--- a/dispatcher/common.go
+++ b/dispatcher/common.go
@@ -18,5 +18,5 @@ type Job struct {
 
 // NewJob returns a new instance of Job. Only call this method if Job.IsInValidState() is true, else can result a panic
 func NewJob(job *data.DeliveryJob) *Job {
-	return &Job{Data: job, Priority: job.Message.Priority}
+	return &Job{Data: job, Priority: job.Priority}
 }

--- a/migration/sqls/000006_add_priority_to_job.down.sql
+++ b/migration/sqls/000006_add_priority_to_job.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `job`
+DROP COLUMN `priority`;

--- a/migration/sqls/000006_add_priority_to_job.up.sql
+++ b/migration/sqls/000006_add_priority_to_job.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `job`
+ADD COLUMN `priority` INTEGER NOT NULL DEFAULT 0;
+
+UPDATE `job`
+SET `priority` = (SELECT `priority` FROM `message` WHERE `id` = `job`.`messageId`)
+WHERE `job`.`status` <> 1003;

--- a/storage/data/job.go
+++ b/storage/data/job.go
@@ -53,6 +53,7 @@ type DeliveryJob struct {
 	DispatchReceivedAt    time.Time
 	EarliestNextAttemptAt time.Time
 	RetryAttemptCount     uint
+	Priority              uint
 }
 
 // QuickFix fixes the object state automatically as much as possible
@@ -113,6 +114,10 @@ func (job *DeliveryJob) GetLockID() string {
 // NewDeliveryJob creates a new instance of DeliveryJob; returns insufficient info error if parameters are not valid for a new DeliveryJob
 func NewDeliveryJob(msg *Message, consumer *Consumer) (job *DeliveryJob, err error) {
 	job = &DeliveryJob{Message: msg, Listener: consumer}
+	if msg != nil {
+		job.Priority = msg.Priority
+	}
+
 	job.QuickFix()
 	if !job.IsInValidState() {
 		err = ErrInsufficientInformationForCreating

--- a/storage/deliveryjobrepo_test.go
+++ b/storage/deliveryjobrepo_test.go
@@ -23,6 +23,7 @@ var (
 
 const (
 	consumerIDPrefix = "test-consumer-for-dj-"
+	messagePriority  = 5
 )
 
 func SetupForDeliveryJobTests() {
@@ -62,6 +63,7 @@ func TestDispatchMessage(t *testing.T) {
 		djRepo := getDeliverJobRepository()
 		msgRepo := getMessageRepository()
 		message := getMessageForJob()
+		message.Priority = messagePriority
 		msgRepo.Create(message)
 		jobs := getDeliveryJobsInFixture(message)
 		err := djRepo.DispatchMessage(message, jobs...)
@@ -81,6 +83,7 @@ func TestDispatchMessage(t *testing.T) {
 			assert.Equal(t, message, dJob.Message)
 			assert.Contains(t, dJob.Listener.ConsumerID, consumerIDPrefix)
 			assert.Equal(t, data.JobQueued, dJob.Status)
+			assert.Equal(t, message.Priority, dJob.Priority)
 		}
 		_, _, err = djRepo.GetJobsForMessage(message, page)
 		assert.Equal(t, ErrPaginationDeadlock, err)


### PR DESCRIPTION
Ticket: [AR-314](https://jira.sso.episerver.net/browse/AR-314)

## Description

The `priority` column from the `message` table is required to sort the queued jobs of a pull based consumer. Since both the `job` table and the `message` table can get quite large, a join query on them can be inefficient. So we're adding a duplicate of the `priority` column in the `job` table.