### PR TITLE
Make Test Non-parallel To Avoid Race Condition

### DIFF
--- a/dispatcher/msgdispatcher_test.go
+++ b/dispatcher/msgdispatcher_test.go
@@ -300,7 +300,6 @@ func TestMessageDispatcherImplDispatch(t *testing.T) {
 		assert.Contains(t, buf.String(), expectedErr.Error())
 	})
 	t.Run("Success", func(t *testing.T) {
-		t.Parallel()
 		t.Cleanup(clearConsumerHandler)
 		var wg sync.WaitGroup
 		oldDeliverJob := deliverJob


### PR DESCRIPTION
This PR stops [this](https://github.com/newscred/webhook-broker/blob/main/dispatcher/msgdispatcher_test.go#L302) test to run parallelly with others, because it mutates and restores a shared function object [here](https://github.com/newscred/webhook-broker/blob/main/dispatcher/msgdispatcher_test.go#L307-L313). 