### PR TITLE
Stop Redundant Lock Acquiring For Jobs with Pull Consumer 

### DIFF
--- a/dispatcher/msgdispatcher.go
+++ b/dispatcher/msgdispatcher.go
@@ -144,6 +144,9 @@ var (
 		defer genericPanicRecoveryFunc()
 		jobs := msgDispatcher.djRepo.GetJobsReadyForInflightSince(msgDispatcher.rationalDelay)
 		for _, job := range jobs {
+			if job.Listener.Type != data.PushConsumer {
+				continue
+			}
 			err := inLockRun(msgDispatcher.lockRepo, job, func() error {
 				queueJob(msgDispatcher, job)
 				return nil


### PR DESCRIPTION
Ticket: https://jira.sso.episerver.net/browse/AR-327
This PR checks job consumer type before acquiring the lock in `retryQueuedJob` go routine. 