### PR TITLE
SKYNET-3052: bump appVersion to 0.2-alpha-early-access

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ type LogLevel uint8
 
 // GetVersion provides the current version of the project
 func GetVersion() AppVersion {
-	return "0.2.0-dev"
+	return "0.2-alpha-early-access"
 }
 
 const (

--- a/deploy-pkg/webhook-broker-chart/Chart.yaml
+++ b/deploy-pkg/webhook-broker-chart/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0-dev
+version: 0.2-alpha-early-access
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.2.0-dev
+appVersion: v0.2-alpha-early-access
 
 keywords:
 - webhook

--- a/main_test.go
+++ b/main_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestGetAppVersion(t *testing.T) {
-	assert.Equal(t, string(GetAppVersion()), "0.2.0-dev")
+	assert.Equal(t, string(GetAppVersion()), "0.2-alpha-early-access")
 }
 
 var mainFunctionBreaker = func(stop *chan os.Signal) {


### PR DESCRIPTION
Increments patch for webhook broker release.