### PR TITLE
AR-336: Mark Pull Job Dead After Max Retry

### DIFF
--- a/docs/tech-specs/pull-consumer-spec.md
+++ b/docs/tech-specs/pull-consumer-spec.md
@@ -5,7 +5,7 @@
 | _Version_     | 1                       |
 | _By_          | Bishwajit Bhattacharjee |
 | _Date_        | February 5, 2023        |
-| _Last Update_ | March 20, 2023          |
+| _Last Update_ | March 27, 2023          |
 
 ## Problem Statement / Goal
 
@@ -42,7 +42,7 @@ We can solve this problem with pull based consumers. With the support of Pull me
 
    The default timeout for a job is calculated as the sum of `stopTimeout` and `rationalDelay`, expressed in seconds. If a consumer is unable to complete the job within this time limit, the broker will requeue the job for retrying. However, different pull jobs may have varying timeout requirements, and therefore, a pull consumer can specify a different timeout value when moving a job from the _JobQueued_ or _JobDead_ status to _JobInflight_ status using the endpoint.
 
-   To specify a custom timeout, when a pull consumer moves a job from _JobQueued_/_JobDead_ to _JobInflight_ through the endpoint, it can optionally pass a field `IncrementalTimeout` in seconds. In that case, if the job is not complete within $stopTimeout + rationalDelay + incrementalTimeout$ seconds, the broker will assume that the consumer failed while executing the job and requeue the job for retrying later with increasing the retry count by one. A job's status can be _JobDead_ if the consumer, while processing the job, decides it cannot process any furthur.
+   To specify a custom timeout, when a pull consumer moves a job from _JobQueued_/_JobDead_ to _JobInflight_ through the endpoint, it can optionally pass a field `IncrementalTimeout` in seconds. In that case, if the job is not complete within $stopTimeout + rationalDelay + incrementalTimeout$ seconds, the broker will assume that the consumer failed while executing the job and requeue the job for retrying later with increasing the retry count by one. The job will be dead if it is retried more than maximum allowed retry count. A job's status can also be _JobDead_ if the consumer, while processing the job, decides it cannot process any furthur.
 
 ```mermaid
 ---

--- a/storage/dataaccess.go
+++ b/storage/dataaccess.go
@@ -68,6 +68,7 @@ type DeliveryJobRepository interface {
 	MarkJobDelivered(deliveryJob *data.DeliveryJob) error
 	MarkJobDead(deliveryJob *data.DeliveryJob) error
 	MarkJobRetry(deliveryJob *data.DeliveryJob, earliestDelta time.Duration) error
+	MarkQueuedJobAsDead(deliveryJob *data.DeliveryJob) error
 	MarkDeadJobAsInflight(deliveryJob *data.DeliveryJob) error
 	RequeueDeadJobsForConsumer(consumer *data.Consumer) error
 	GetJobsForMessage(message *data.Message, page *data.Pagination) ([]*data.DeliveryJob, *data.Pagination, error)

--- a/storage/deliveryjobrepo.go
+++ b/storage/deliveryjobrepo.go
@@ -82,6 +82,10 @@ func (djRepo *DeliveryJobDBRepository) MarkJobDead(deliveryJob *data.DeliveryJob
 	return djRepo.updateJobStatus(deliveryJob, data.JobInflight, data.JobDead)
 }
 
+func (djRepo *DeliveryJobDBRepository) MarkQueuedJobAsDead(deliveryJob *data.DeliveryJob) error {
+	return djRepo.updateJobStatus(deliveryJob, data.JobQueued, data.JobDead)
+}
+
 // MarkJobRetry increases the retry attempt count and sets the status of the job to Queued if the job's current status is Inflight in the object and DB; else returns error
 func (djRepo *DeliveryJobDBRepository) MarkJobRetry(deliveryJob *data.DeliveryJob, earliestDelta time.Duration) (err error) {
 	currentTime := time.Now()

--- a/storage/deliveryjobrepo.go
+++ b/storage/deliveryjobrepo.go
@@ -215,7 +215,7 @@ func (djRepo *DeliveryJobDBRepository) GetJobsForMessage(message *data.Message, 
 func (djRepo *DeliveryJobDBRepository) RequeueDeadJobsForConsumer(consumer *data.Consumer) (err error) {
 	currentTime := time.Now()
 	err = transactionalWrites(djRepo.db, func(tx *sql.Tx) error {
-		return inTransactionExec(tx, emptyOps, "UPDATE job SET status = ?, statusChangedAt = ?, updatedAt = ? WHERE consumerId like ? and status = ?", args2SliceFnWrapper(data.JobQueued, currentTime, currentTime, consumer.ID, data.JobDead), 0)
+		return inTransactionExec(tx, emptyOps, "UPDATE job SET status = ?, statusChangedAt = ?, updatedAt = ?, retryAttemptCount = ? WHERE consumerId like ? and status = ?", args2SliceFnWrapper(data.JobQueued, currentTime, currentTime, 0, consumer.ID, data.JobDead), 0)
 	})
 	return err
 }

--- a/storage/deliveryjobrepo_test.go
+++ b/storage/deliveryjobrepo_test.go
@@ -457,6 +457,7 @@ func TestRequeueDeadJobsForConsumer(t *testing.T) {
 		job, err := djRepo.GetByID(testJob.ID.String())
 		assert.Nil(t, err)
 		assert.Equal(t, data.JobQueued, job.Status)
+		assert.Equal(t, uint(0), job.RetryAttemptCount)
 	}
 }
 

--- a/storage/mocks/DeliveryJobRepository.go
+++ b/storage/mocks/DeliveryJobRepository.go
@@ -247,6 +247,20 @@ func (_m *DeliveryJobRepository) MarkJobRetry(deliveryJob *data.DeliveryJob, ear
 	return r0
 }
 
+// MarkQueuedJobAsDead provides a mock function with given fields: deliveryJob
+func (_m *DeliveryJobRepository) MarkQueuedJobAsDead(deliveryJob *data.DeliveryJob) error {
+	ret := _m.Called(deliveryJob)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*data.DeliveryJob) error); ok {
+		r0 = rf(deliveryJob)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RequeueDeadJobsForConsumer provides a mock function with given fields: consumer
 func (_m *DeliveryJobRepository) RequeueDeadJobsForConsumer(consumer *data.Consumer) error {
 	ret := _m.Called(consumer)


### PR DESCRIPTION
Ticket: https://jira.sso.episerver.net/browse/AR-336

This PR accomplishes two things:

1. Marks the pull jobs as dead when they exceed maximum retry count. Previously whenever the pull jobs were retried, their `retryAttemptCount` were increased, but were not marked as *Dead* when the max retry count exceeds. 

2. Makes `RetryAttemptCount` to 0 when jobs are pulled in from dlq. Previously when jobs are requeued from dlq, their previous retry count were not being reset to 0. The code flow is such that for push job, each job will be tried once more and mark dead if fails again. However, for pull jobs without resetting the retry count, the jobs will be put back in `JobDead` state just after they are pulled in from the dlq.
