### PR TITLE
Add preStop hook to webhook-broker container for handling 502 erros during pod scale down

### DIFF
--- a/deploy-pkg/webhook-broker-chart/Chart.yaml
+++ b/deploy-pkg/webhook-broker-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2-alpha-early-access
+version: 0.2-alpha-early-access.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
+++ b/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 30"]
           command: ["/webhook-broker"]
           args: ["-migrate", "/migration/sqls/", "-config", "/app-config/webhook-broker.cfg"{{ if eq .Values.broker.configFileWatchMode "stop" }}, "-stop-on-conf-change"{{ end }}{{ if eq .Values.broker.configFileWatchMode "ignore" }}, "-do-not-watch-conf-change"{{ end }}]
           ports:


### PR DESCRIPTION
TICKET: https://jira.sso.episerver.net/browse/<TICKET-ID>

Related PRs:
- ...

## Description

Webhook-broker fails with 502 error when pod count scales down, the errors come from the terminated pods. Request gets served to those pods. The preStop hook should allow those requests to be completed from the pod is terminated.

## QA Steps

- [ ] <!-- Step to test change -->
