### PR TITLE
Add location header to broadcast endpoint

### DIFF
--- a/controllers/broadcast.go
+++ b/controllers/broadcast.go
@@ -23,6 +23,7 @@ const (
 	headerProducerToken       = "X-Broker-Producer-Token"
 	headerProducerID          = "X-Broker-Producer-ID"
 	headerMessageID           = "X-Broker-Message-ID"
+	headerLocation            = "Location"
 	defaultMessageContentType = "application/octet-stream"
 	messageIDLogFieldKey      = "messageId"
 )
@@ -71,7 +72,8 @@ func (broadcastController *BroadcastController) Post(w http.ResponseWriter, r *h
 	if err = broadcastController.MessageRepository.Create(message); err == nil {
 		logger.Info().Str(messageIDLogFieldKey, message.ID.String()).Msg("Message accepted for broadcast")
 		go broadcastController.Dispatcher.Dispatch(message)
-		writeStatus(w, http.StatusAccepted, nil)
+		w.Header().Add(headerLocation, "/channel/"+channel.ChannelID+"/message/"+message.MessageID)
+		writeStatus(w, http.StatusCreated, nil)
 	} else if err == storage.ErrDuplicateMessageIDForChannel {
 		logger.Error().Err(err).Str(messageIDLogFieldKey, message.ID.String()).Msg("message rejected because its duplicate id in channel")
 		writeStatus(w, http.StatusConflict, err)

--- a/controllers/broadcast_test.go
+++ b/controllers/broadcast_test.go
@@ -192,7 +192,7 @@ func TestBroadcastControllerPost(t *testing.T) {
 		msgRepo.AssertExpectations(t)
 		mockDispatcher.AssertExpectations(t)
 	})
-	t.Run("Success:202-Accepted", func(t *testing.T) {
+	t.Run("Success:201-Created", func(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer
 		oldLogger := log.Logger
@@ -225,8 +225,10 @@ func TestBroadcastControllerPost(t *testing.T) {
 		rr := httptest.NewRecorder()
 		testRouter.ServeHTTP(rr, req)
 		wg.Wait()
-		assert.Equal(t, http.StatusAccepted, rr.Code)
+		assert.Equal(t, http.StatusCreated, rr.Code)
 		responseReqID := rr.Header().Get(headerRequestID)
+		location := rr.Header().Get(headerLocation)
+		assert.Contains(t, location, "/channel/"+consumerTestChannel.ChannelID+"/message/")
 		assert.GreaterOrEqual(t, len(responseReqID), 12)
 		assert.Contains(t, buf.String(), responseReqID)
 		assert.Contains(t, buf.String(), messageIDLogFieldKey)
@@ -288,7 +290,7 @@ func TestBroadcastControllerPost(t *testing.T) {
 		rr := httptest.NewRecorder()
 		testRouter.ServeHTTP(rr, req)
 		wg.Wait()
-		assert.Equal(t, http.StatusAccepted, rr.Code)
+		assert.Equal(t, http.StatusCreated, rr.Code)
 		msgRepo.AssertExpectations(t)
 		mockDispatcher.AssertExpectations(t)
 	})
@@ -317,7 +319,7 @@ func TestBroadcastControllerPost(t *testing.T) {
 		rr := httptest.NewRecorder()
 		testRouter.ServeHTTP(rr, req)
 		wg.Wait()
-		assert.Equal(t, http.StatusAccepted, rr.Code)
+		assert.Equal(t, http.StatusCreated, rr.Code)
 		msgRepo.AssertExpectations(t)
 		mockDispatcher.AssertExpectations(t)
 	})
@@ -350,7 +352,7 @@ func TestBroadcastControllerPost(t *testing.T) {
 		rr := httptest.NewRecorder()
 		testRouter.ServeHTTP(rr, req)
 		wg.Wait()
-		assert.Equal(t, http.StatusAccepted, rr.Code)
+		assert.Equal(t, http.StatusCreated, rr.Code)
 		responseReqID := rr.Header().Get(headerRequestID)
 		assert.Equal(t, reqID, responseReqID)
 		msgRepo.AssertExpectations(t)

--- a/controllers/message.go
+++ b/controllers/message.go
@@ -40,6 +40,7 @@ type DLQList struct {
 
 // MessageModel represents a single message
 type MessageModel struct {
+	ID           string
 	Payload      string
 	ContentType  string
 	ProducedBy   string
@@ -51,6 +52,7 @@ type MessageModel struct {
 
 func newMessageModel(message *data.Message, jobs ...*data.DeliveryJob) *MessageModel {
 	messageModel := &MessageModel{
+		ID:           message.MessageID,
 		Payload:      message.Payload,
 		ContentType:  message.ContentType,
 		ReceivedAt:   message.ReceivedAt,

--- a/dispatcher/worker.go
+++ b/dispatcher/worker.go
@@ -21,6 +21,7 @@ const (
 	headerContentType    = "Content-Type"
 	headerBrokerPriority = "X-Broker-Message-Priority"
 	headerConsumerToken  = "X-Broker-Consumer-Token"
+	headerMessageID      = "X-Broker-Message-ID"
 	headerRequestID      = "X-Request-ID"
 	requestIDLogFieldKey = "requestId"
 	jobIDLogFieldKey     = "jobId"
@@ -122,6 +123,7 @@ var callConsumer = func(httpClient *http.Client, requestID string, logger zerolo
 		req.Header.Set(headerBrokerPriority, strconv.Itoa(int(job.Priority)))
 		req.Header.Set(headerConsumerToken, job.Data.Listener.Token)
 		req.Header.Set(headerRequestID, requestID)
+		req.Header.Set(headerMessageID, job.Data.Message.MessageID)
 		var resp *http.Response
 		resp, err = httpClient.Do(req)
 		if err == nil {

--- a/integration-test/main.go
+++ b/integration-test/main.go
@@ -318,7 +318,7 @@ func broadcastMessage(channelID string, sendCount int) (err error) {
 			log.Println("error broadcasting to consumers", err)
 		} else {
 			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusAccepted {
+			if resp.StatusCode != http.StatusCreated {
 				respBody, _ := ioutil.ReadAll(resp.Body)
 				log.Println("error broadcasting message", resp.StatusCode, string(respBody))
 				err = errDuringCreation


### PR DESCRIPTION
TICKET: https://jira.sso.episerver.net/browse/<TICKET-ID>

Related PRs:
- ...

## Description

- user can now log `messageId` after broadcasting

## QA Steps

- [ ] <!-- Step to test change -->
