### PR TITLE
feat: Add alternative index for querying retry messages

### DIFF
--- a/migration/sqls/000010_add_alt_retry_index.down.sql
+++ b/migration/sqls/000010_add_alt_retry_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX `retry_dispatch_alt` on `message`;

--- a/migration/sqls/000010_add_alt_retry_index.up.sql
+++ b/migration/sqls/000010_add_alt_retry_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `retry_dispatch_alt` on `message` (`status`, `receivedAt`, `createdAt`, `id`);


### PR DESCRIPTION
## Description

Some of the queries on the `message` table access the columns in the order (`createdAt`, `id`), which doesn't match any existing index.


The existing index `retry_dispatch` has the column order (`status`, `receivedAt`, `id`, `createdAt`).

This PR adds a new index `retry_dispatch_alt` (`status`, `receivedAt`, `createdAt`, `id`), enabling queries that access the columns in a (`createdAt`, `id`) order to use the index