### PR TITLE
ensure fileblob does not create temp files in OS's temp directory (respects 'export-path' config instead)

### DIFF
--- a/prune/service.go
+++ b/prune/service.go
@@ -46,7 +46,7 @@ var (
 		dirPath := fmt.Sprintf("file://%s/%s", pruneConfig.GetExportPath(), pruneConfig.GetRemoteFilePrefix())
 		objectName := fmt.Sprintf("local_%s_%s.jsonl", pruneConfig.GetExportNodeName(), now)
 		log.Info().Msgf("Local archive path: %s, object name: %s", dirPath, objectName)
-		fileBucket, err := blob.OpenBucket(context.Background(), dirPath)
+		fileBucket, err := blob.OpenBucket(context.Background(), dirPath+"?no_tmp_dir=1")
 		if err != nil {
 			return nil, fmt.Errorf("failed to open local archive file: %w", err)
 		}


### PR DESCRIPTION
## Description
Go fileblob creates local files using `os.tempdir` which tries to create files in `/tmp` in Linux. If we try to store the final files in a path mounted by an external volume (e.g: PV in K8s), this produces a `invalid cross device link` error. Details: https://github.com/google/go-cloud/issues/3294
Furthermore, the `/tmp` path lies under the pod ephemeral storage in K8s and therefore, the disk size is not guaranteed!

This PR addresses the issue by applying the suggested solutions by the maintainers of fileblob. The solution is to append a `no_tmp_dir` query parameter to `file://` urls. This should allow using K8s persistent volumes to store local archive files during db pruning. 