### PR TITLE
Fix content-type header checking

### DIFF
--- a/controllers/producer.go
+++ b/controllers/producer.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
@@ -108,7 +109,8 @@ func (prodController *ProducerController) Put(w http.ResponseWriter, r *http.Req
 
 func checkFormContentType(r *http.Request, w http.ResponseWriter) bool {
 	validRequest := true
-	if r.Header.Get(headerContentType) != formDataContentTypeHeaderValue {
+	contentType, _, _ := strings.Cut(r.Header.Get(headerContentType), ";")
+	if contentType != formDataContentTypeHeaderValue {
 		validRequest = false
 		writeUnsupportedMediaType(w)
 	}


### PR DESCRIPTION
TICKET: https://jira.sso.episerver.net/browse/<TICKET-ID>

Related PRs:
- ...

## Description

HTTP Clients can automatically add `;charset=UTF-8` suffix to `content-type` header depending on environment and content.

## QA Steps

- [ ] <!-- Step to test change -->
