### PR TITLE
0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This contains all the release of the project from oldest to newest.
 
+## Release `0.2.2`
+Bug fix: Webhook broker prune job gets stuck for hours due to MySQL not being able to utilize indexes for the `pruneMessageQuery`
+
 ## Release `0.2.1`
 
 ### New Features
@@ -21,7 +24,7 @@ This contains all the release of the project from oldest to newest.
 
 ## Release `0.2.0`
 
-This includes all issues with milestone [v0.2](https://github.com/newscred/webhook-broker/issues?q=is%3Aissue%20state%3Aclosed%20milestone%3Av0.2). 
+This includes all issues with milestone [v0.2](https://github.com/newscred/webhook-broker/issues?q=is%3Aissue%20state%3Aclosed%20milestone%3Av0.2).
 
 ## Release `0.1.2`
 

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ type LogLevel uint8
 
 // GetVersion provides the current version of the project
 func GetVersion() AppVersion {
-	return "0.3.0-dev"
+	return "0.2.2"
 }
 
 const (

--- a/deploy-pkg/webhook-broker-chart/Chart.yaml
+++ b/deploy-pkg/webhook-broker-chart/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0-dev
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.3.0-dev
+appVersion: v0.2.2
 
 keywords:
 - webhook

--- a/main_test.go
+++ b/main_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestGetAppVersion(t *testing.T) {
-	assert.Equal(t, string(GetAppVersion()), "0.3.0-dev")
+	assert.Equal(t, string(GetAppVersion()), "0.2.2")
 }
 
 var waitForPort = func(portNum int) {


### PR DESCRIPTION
## Description
### Release `0.2.2`
- Refer to the [CHANGELOG](https://github.com/newscred/webhook-broker/blob/main/CHANGELOG.md#release-021) for details.