### PR TITLE
Fix broken action jobs

### DIFF
--- a/.github/scripts/split-sarif.py
+++ b/.github/scripts/split-sarif.py
@@ -1,0 +1,19 @@
+import json
+import os
+
+INPUT_FILE = "snyk.sarif"
+OUTPUT_DIR = "snyk-split-runs"
+
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+with open(INPUT_FILE, "r") as f:
+    sarif = json.load(f)
+
+for i, run in enumerate(sarif.get("runs", [])):
+    split_file = os.path.join(OUTPUT_DIR, f"snyk_{i}.sarif")
+    with open(split_file, "w") as out:
+        print("RUN:", i, run)
+        json.dump({
+            "version": sarif["version"],
+            "runs": [run]
+        }, out)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,32 +25,3 @@ jobs:
       with:
         name: dist-app
         path: dist/webhook-broker-*.tar.bz2
-
-  coverage:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: "check is CODECLIMATE_REPORTER_ID exists"
-      env:
-          super_secret: ${{ secrets.CODECLIMATE_REPORTER_ID }}
-      if: ${{ env.super_secret == '' }}
-      run: 'echo "echo the secret \"CODECLIMATE_REPORTER_ID\" has not been made; echo please go to \"settings \> secrets \> actions\" to create it"'
-    - uses: actions/checkout@master
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.23.0'
-    - name: Create dist
-      run: mkdir ./dist/
-    - name: Install dependencies
-      run: make dep-tools deps
-    - uses: paambaati/codeclimate-action@v2.7.5
-      if: ${{ env.CC_TEST_REPORTER_ID != '' }}
-      env:
-        CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_REPORTER_ID }}
-      with:
-        coverageCommand: go test -timeout 30s -coverprofile=cover.out ./... -short
-        debug: true
-        prefix: github.com/newscred/webhook-broker/
-        coverageLocations: |
-          ${{github.workspace}}/*.out:gocov

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,10 +48,10 @@ jobs:
         image: your/image-to-test
         args: --file=Dockerfile --sarif-file-output=snyk.sarif
 
-    - name: Set up Python 3.9 (required for sarif-toolkit)
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.13'
 
     - name: Split SARIF file manually
       run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,16 +23,19 @@ on:
 jobs:
 
   snyk:
+    permissions:
+      contents: read
+      security-events: write
     name: Snyk Container Test
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Build a Docker image
       run: docker build -t your/image-to-test .
-    - name: Run Snyk to check Docker image for vulnerabilities
-      # Snyk can be used to break the build when it detects vulnerabilities.
-      # In this case we want to upload the issues to GitHub Code Scanning
+
+    - name: Run Snyk to check Docker image for vulnerabilities and output SARIF
       continue-on-error: true
       uses: snyk/actions/docker@master
       env:
@@ -43,14 +46,29 @@ jobs:
       if: ${{ env.SNYK_TOKEN != '' }}
       with:
         image: your/image-to-test
-        args: --file=Dockerfile
-    - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v1
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      if: ${{ env.SNYK_TOKEN != '' }}
+        args: --file=Dockerfile --sarif-file-output=snyk.sarif
+
+    - name: Set up Python 3.9 (required for sarif-toolkit)
+      uses: actions/setup-python@v5
       with:
-        sarif_file: snyk.sarif
+        python-version: '3.9'
+
+    - name: Split SARIF file manually
+      run: |
+        python3 .github/scripts/split-sarif.py
+
+    - run: ls -la snyk-split-runs/
+    - name: Upload Snyk Docker SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: snyk-split-runs/snyk_0.sarif
+        category: snyk-docker-image
+
+    - name: Upload Snyk Go Modules SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: snyk-split-runs/snyk_1.sarif
+        category: snyk-gomodules
 
   analyze:
     permissions:
@@ -79,7 +97,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         debug: true
         languages: ${{ matrix.language }}
@@ -107,4 +125,4 @@ jobs:
        make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release-containers.yml
+++ b/.github/workflows/release-containers.yml
@@ -40,32 +40,34 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    -
-      uses: docker/login-action@v1
-      name: Login to Github Docker Registry
-      env:
-        gcr_pat: ${{ secrets.CR_PAT }}
-      if: ${{ env.gcr_pat != '' }}
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
+        username: newscred
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "VERSION=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
 
     -
       uses: docker/build-push-action@v2
-      name: Push
-      id: build_push
+      name: Push to GHCR
+      with:
+        push: true
+        platforms: linux/amd64,linux/arm64
+        tags: |
+          ghcr.io/newscred/webhook-broker:${{ steps.get_version.outputs.VERSION }}
+
+    -
+      uses: docker/build-push-action@v2
+      name: Push to DockerHub
       env:
-        gcr_pat: ${{ secrets.CR_PAT }}
         dockerhub_setup: ${{ secrets.DOCKERHUB_USERNAME }}
-      if: ${{ env.gcr_pat != '' && env.dockerhub_setup != '' }}
+      if: ${{ env.dockerhub_setup != '' }}
       with:
         push: true
         platforms: linux/amd64,linux/arm64
         tags: |
           imyousuf/webhook-broker:${{ steps.get_version.outputs.VERSION }}
-          ghcr.io/imyousuf/webhook-broker:${{ steps.get_version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ![webhook-broker CI](https://github.com/newscred/webhook-broker/actions/workflows/build.yml/badge.svg)
 ![webhook-broker Container CI](https://github.com/newscred/webhook-broker/actions/workflows/container-build.yml/badge.svg)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/0242f0e077ad68716c26/test_coverage)](https://codeclimate.com/github/newscred/webhook-broker/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/0242f0e077ad68716c26/maintainability)](https://codeclimate.com/github/newscred/webhook-broker/maintainability)
 [![Go Report Card](https://goreportcard.com/badge/github.com/newscred/webhook-broker)](https://goreportcard.com/report/github.com/newscred/webhook-broker)
 
 This is a fully HTTP based Pub/Sub Broker with a goal to simplify systems architected in SOA or Microservice architecture. It aims to solve the inter service communication problem.


### PR DESCRIPTION
Addresses the following issues on actions jobs:
- Update codeql action version to v3 since, v1 was no longer supported and was failing jobs.
- split .sarif files to handle: https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/
- CodeClimate is [no longer available](https://docs.qlty.sh/migration/guide). Cleanup codeclimate and create ticket for [QLTY migration](https://jira.sso.episerver.net/browse/SKYNET-4741)
- Fix broken container image push for GHCR
