### PR TITLE
SKYNET-5237: Add RDS CA certificate bundle for SSL certificate verification

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -3,6 +3,7 @@ name: Webhook Broker Container Build & Push
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN make test
 
 FROM alpine:3.20
 RUN apk update && apk add curl
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 WORKDIR /
 COPY --from=build-env /go/src/github.com/newscred/webhook-broker/webhook-broker /webhook-broker
 COPY --from=build-env /go/src/github.com/newscred/webhook-broker/migration /migration


### PR DESCRIPTION

## Description
Adds Amazon RDS global CA bundle to the Docker image so that `tls=true` in the MySQL connection string can properly verify the RDS server certificate.



## How to test?
- [ ] Deploy to dev and verify all 3 webhook-broker variants start without TLS errors
- [ ] Verify SSL connection: `SHOW STATUS LIKE 'Ssl_cipher'` shows TLS cipher