### PR TITLE
Add optional startupProbe support to deployment template

### DIFF
--- a/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
+++ b/deploy-pkg/webhook-broker-chart/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
               port: {{ .Values.broker.port }}
             initialDelaySeconds: {{ .Values.broker.probeInitialDelay }}
             periodSeconds: {{ .Values.broker.probeInterval }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:


### PR DESCRIPTION
TICKET:

## Description

Adds a conditional `startupProbe` block to the deployment template. When `.Values.startupProbe` is defined, the probe is rendered; otherwise, no change in behavior (backward compatible).

Uses `/_status` which queries the DB for app seed data — implicitly verifies DB connectivity.

## How to test?

- [ ] Deploy with `startupProbe` values set — verify probe appears in pod spec
- [ ] Deploy without `startupProbe` values — verify no change in behavior

## Reminders
- Companion PR in configuration-management adds the values to activate the probe