### PR TITLE
fix(storage): bound queued-jobs query cost with prioritized index

### DIFF
--- a/docs/runbooks/drain-queued-backlog.md
+++ b/docs/runbooks/drain-queued-backlog.md
@@ -1,0 +1,152 @@
+# Runbook: Drain a stuck QUEUED backlog for a pull consumer
+
+## When to use this
+
+A pull consumer's `GET /channel/{channel}/consumer/{consumer}/queued-jobs` request
+times out (HTTP 504 at ~60s), the consumer cannot fetch, its QUEUED backlog keeps
+growing, and it never recovers on its own (death spiral).
+
+Root cause and the permanent fix (composite index + `consumerId = ?`) are covered in
+migration `000013_add_prioritized_jobs_index` and `storage/deliveryjobrepo.go`. **Apply
+the code fix first** — it prevents recurrence. This runbook clears the *already
+accumulated* backlog so the consumer can recover, because there is no HTTP endpoint that
+purges QUEUED jobs.
+
+> **Status integers (verify before running anything):** QUEUED=**1001**, INFLIGHT=1002,
+> DELIVERED=1003, DEAD=1004. Defined in `storage/data/job.go` (`iota + 1000`, with
+> `deliverJobLockPrefix` consuming iota=0). **QUEUED is 1001, not 1000.** Using 1000
+> matches nothing.
+
+## Preconditions & scope
+
+- **Both deployments.** There are two independent brokers (AWS and GCP) with their own
+  MySQL databases and the same channel/consumer names. Perform the drain **on each**.
+- **Dropping stale QUEUED jobs is acceptable** for the affected consumer: the downstream
+  consumer backfills missed events out-of-band. Confirm this is still true for the
+  specific consumer before deleting.
+- This is a **DBA / maintainer action on shared production**. Take a snapshot/backup or
+  ensure PITR is available first. Do not run destructive statements without sign-off.
+
+## Part A — Zero-downtime index rollout (do this before/with the code deploy)
+
+Migrations run **synchronously at app startup** under a lock (`storage/rdbms.go`), so a
+blocking `CREATE INDEX` on the large `job` table could stall pod startup / trip the
+startupProbe. Migration 000013 is therefore **idempotent** (creates only if absent).
+
+Recommended sequence per database:
+
+1. **Build the index out-of-band first** (online, non-blocking). Preferred, replication-safe:
+   ```bash
+   gh-ost \
+     --host=<primary> --database=webhook-broker --table=job \
+     --alter="ADD INDEX \`job_consumer_status_priority\` (\`consumerId\`, \`status\`, \`priority\` DESC, \`createdAt\` DESC, \`id\` DESC)" \
+     --allow-on-master --max-lag-millis=1500 --exact-rowcount --execute
+   ```
+   Or, if `gh-ost`/`pt-online-schema-change` is not available and traffic tolerates it:
+   ```sql
+   CREATE INDEX `job_consumer_status_priority`
+     ON `job` (`consumerId`, `status`, `priority` DESC, `createdAt` DESC, `id` DESC)
+     ALGORITHM=INPLACE LOCK=NONE;
+   ```
+   `LOCK=NONE` keeps reads/writes flowing during the build; expect extra IO/CPU and some
+   replica lag on a large table — run during a low-traffic window and watch lag.
+
+2. **Deploy the code.** At startup, migration 000013 sees the index already exists and is
+   an instant no-op — no blocking DDL, no held lock.
+
+3. Verify the index exists:
+   ```sql
+   SELECT index_name FROM information_schema.statistics
+   WHERE table_schema = DATABASE() AND table_name = 'job'
+     AND index_name = 'job_consumer_status_priority';
+   ```
+
+> If the index is *not* pre-built, the in-band fallback still runs the **online**
+> `ALGORITHM=INPLACE, LOCK=NONE` create (never a blocking rebuild) and is safe to re-run —
+> but it will hold the migration during the build, so pre-building is strongly preferred on
+> the large prod table.
+
+## Part B — Drain the existing QUEUED backlog (primary method: scoped batched DELETE)
+
+Run on **each** database (AWS and GCP).
+
+### B1. Resolve the internal consumer id
+
+The `job.consumerId` column stores the consumer's **internal `consumer.id`** (a xid), not
+the human-facing `consumerId`/name. Resolve it by the public consumer id + channel:
+
+```sql
+SELECT c.id AS internal_consumer_id, c.consumerId, c.channelId, c.name
+FROM consumer c
+WHERE c.consumerId = '<public-consumer-id>'   -- e.g. shamwow-asset-modified-consumer
+  AND c.channelId  = '<channel-id>';          -- e.g. eb_cmp_asset_modified
+```
+
+Record `internal_consumer_id`. All statements below use it.
+
+### B2. Confirm the backlog size (read-only)
+
+```sql
+SELECT COUNT(*) AS queued_count
+FROM job
+WHERE consumerId = '<internal_consumer_id>' AND status = 1001;  -- 1001 = QUEUED
+```
+
+Sanity-check the number matches the observed backlog before deleting.
+
+### B3. Batched delete (avoid long locks / replication lag)
+
+Delete in bounded batches rather than one large transaction. Loop until 0 rows affected:
+
+```sql
+-- Repeat until "Rows matched: 0". Pause briefly between batches; watch replica lag.
+DELETE FROM job
+WHERE consumerId = '<internal_consumer_id>' AND status = 1001
+LIMIT 5000;
+```
+
+Example shell loop (MySQL CLI):
+```bash
+INTERNAL_ID='<internal_consumer_id>'
+while :; do
+  n=$(mysql -N -B webhook-broker -e \
+    "DELETE FROM job WHERE consumerId='$INTERNAL_ID' AND status=1001 LIMIT 5000; SELECT ROW_COUNT();")
+  echo "deleted batch: $n"
+  [ "$n" -eq 0 ] && break
+  sleep 1   # let replicas catch up
+done
+```
+
+> **Scope tightly.** Always include both `consumerId = '<internal_consumer_id>'` **and**
+> `status = 1001`. Never delete by status alone or across consumers. Only QUEUED (1001) is
+> removed — INFLIGHT/DELIVERED/DEAD jobs are untouched.
+
+### B4. Verify drained
+
+```sql
+SELECT COUNT(*) FROM job
+WHERE consumerId = '<internal_consumer_id>' AND status = 1001;   -- expect 0
+```
+
+Then confirm the consumer's `queued-jobs` endpoint returns quickly (well under 60s) and the
+consumer resumes fetching.
+
+### B5. Repeat on the other deployment
+
+Perform B1–B4 on the second broker's database (the AWS and GCP hosts are independent).
+
+## Alternatives (not recommended as primary)
+
+- **Reclassify QUEUED → DEAD then purge via DLQ endpoint.**
+  `UPDATE job SET status = 1004, statusChangedAt = NOW() WHERE consumerId = '<id>' AND status = 1001;`
+  then `DELETE /channel/{channel}/consumer/{consumer}/dlq`. Uses a sanctioned API path but
+  touches more rows/state and updates DLQ summary counters; slower and higher blast radius.
+  Only consider if a pure DELETE is disallowed by policy.
+
+## Post-drain checklist
+
+- [ ] Index `job_consumer_status_priority` present on **both** DBs.
+- [ ] Code fix deployed (migration 000013 + `consumerId = ?` query) on both brokers.
+- [ ] QUEUED count for the affected consumer == 0 on both DBs.
+- [ ] `queued-jobs` latency back to milliseconds; consumer fetching normally.
+- [ ] Backfill of any dropped events kicked off on the consumer side (out-of-band).

--- a/migration/sqls/000013_add_prioritized_jobs_index.down.sql
+++ b/migration/sqls/000013_add_prioritized_jobs_index.down.sql
@@ -1,0 +1,17 @@
+-- Drop the prioritized queued-jobs index (idempotent).
+
+{{if eq .Dialect "mysql"}}
+SET @idx_exists := (
+    SELECT COUNT(1) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'job'
+      AND index_name = 'job_consumer_status_priority'
+);
+SET @ddl := IF(@idx_exists > 0,
+    'DROP INDEX `job_consumer_status_priority` ON `job`',
+    'DO 0');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+{{else}}
+DROP INDEX IF EXISTS `job_consumer_status_priority`;
+{{end}}

--- a/migration/sqls/000013_add_prioritized_jobs_index.up.sql
+++ b/migration/sqls/000013_add_prioritized_jobs_index.up.sql
@@ -1,0 +1,30 @@
+-- Add composite index backing the pull-consumer queued-jobs query:
+--   SELECT ... FROM job WHERE consumerId = ? AND status = ?
+--   ORDER BY priority DESC, createdAt DESC, id DESC LIMIT ?
+-- Column order matches WHERE-equality columns first, then the ORDER BY columns in
+-- order/direction, so the DB satisfies both the filter and the sort from the index
+-- (no filesort) and LIMIT can terminate early. Without it the query filesorts the
+-- consumer's entire QUEUED backlog -> O(backlog) latency -> 504 for busy consumers.
+--
+-- This migration is idempotent so it can be a no-op at app startup when the index has
+-- already been built out-of-band (gh-ost / pt-online-schema-change / ALGORITHM=INPLACE,
+-- LOCK=NONE). See docs/runbooks/drain-queued-backlog.md for the zero-downtime rollout.
+
+{{if eq .Dialect "mysql"}}
+-- Create only if missing; build online (non-blocking) when it must run in-band.
+SET @idx_exists := (
+    SELECT COUNT(1) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'job'
+      AND index_name = 'job_consumer_status_priority'
+);
+SET @ddl := IF(@idx_exists = 0,
+    'CREATE INDEX `job_consumer_status_priority` ON `job` (`consumerId`, `status`, `priority` DESC, `createdAt` DESC, `id` DESC) ALGORITHM=INPLACE LOCK=NONE',
+    'DO 0');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+{{else}}
+CREATE INDEX IF NOT EXISTS `job_consumer_status_priority` ON `job` (`consumerId`, `status`, `priority` DESC, `createdAt` DESC, `id` DESC);
+{{end}}
+
+-- Generated with assistance from Claude AI

--- a/storage/deliveryjobrepo.go
+++ b/storage/deliveryjobrepo.go
@@ -276,11 +276,17 @@ func (djRepo *DeliveryJobDBRepository) GetJobsForConsumer(consumer *data.Consume
 	return djRepo.getJobs(baseQuery, nil, consumer, appendWithPaginationArgs(page, consumer.ID.String(), jobStatus))
 }
 
+// prioritizedJobsForConsumerQuery backs GetPrioritizedJobsForConsumer (and its plan
+// regression test). It uses `=` (not `like`) on consumerId so the equality lets the DB
+// satisfy the ORDER BY from the job_consumer_status_priority index (migration 000013)
+// instead of filesorting the consumer's entire QUEUED backlog -> O(backlog) latency ->
+// 504 for busy consumers. A `like` on the leading column is treated as a range, which
+// defeats the index-ordered sort. consumerId is always an exact xid, so `=` is equivalent.
+const prioritizedJobsForConsumerQuery = jobCommonSelectQuery + " consumerId = ? AND status = ? ORDER BY priority DESC, createdAt DESC, id DESC LIMIT ?"
+
 // GetPrioritizedJobsForConsumer retrieves DeliveryJob created for delivery to a customer and it has to be filtered by a specific status and ordered by message priority
 func (djRepo *DeliveryJobDBRepository) GetPrioritizedJobsForConsumer(consumer *data.Consumer, jobStatus data.JobStatus, pageSize int) ([]*data.DeliveryJob, error) {
-	orderClause := "ORDER BY priority DESC, createdAt DESC, id DESC"
-	baseQuery := jobCommonSelectQuery + " consumerId like ? AND status = ? " + orderClause + " LIMIT ?"
-	jobs, _, err := djRepo.getJobs(baseQuery, nil, consumer, args2SliceFnWrapper(consumer.ID.String(), jobStatus, pageSize)())
+	jobs, _, err := djRepo.getJobs(prioritizedJobsForConsumerQuery, nil, consumer, args2SliceFnWrapper(consumer.ID.String(), jobStatus, pageSize)())
 	return jobs, err
 }
 

--- a/storage/deliveryjobrepo_test.go
+++ b/storage/deliveryjobrepo_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -442,6 +443,30 @@ func TestGetPrioritizedJobsForConsumer(t *testing.T) {
 		assert.True(t, sort.SliceIsSorted(rJobs, func(i, j int) bool {
 			return rJobs[i].Message.Priority > rJobs[j].Message.Priority
 		}))
+	})
+	// Regression guard: the ACTUAL query used by GetPrioritizedJobsForConsumer
+	// (prioritizedJobsForConsumerQuery) must be served by the job_consumer_status_priority
+	// index (migration 000013) with no filesort. Without it the DB filesorts the whole QUEUED
+	// backlog -> O(backlog) latency -> 504 for busy consumers. This binds to the real query
+	// const, so reverting `=` back to `like` (which filesorts) fails the test. Runs against the
+	// SQLite test DB; SQLite reports a filesort as "USE TEMP B-TREE FOR ORDER BY".
+	t.Run("UsesPrioritizedIndexNoFilesort", func(t *testing.T) {
+		query := "EXPLAIN QUERY PLAN " + prioritizedJobsForConsumerQuery
+		rows, err := testDB.Query(query, testJob.Listener.ID.String(), data.JobQueued, 25)
+		assert.NoError(t, err)
+		defer rows.Close()
+		var plan strings.Builder
+		for rows.Next() {
+			var id, parent, notused int
+			var detail string
+			assert.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+			plan.WriteString(detail)
+			plan.WriteString("\n")
+		}
+		assert.NoError(t, rows.Err())
+		planStr := plan.String()
+		assert.Contains(t, planStr, "job_consumer_status_priority", "query should use the prioritized index; plan was:\n"+planStr)
+		assert.NotContains(t, planStr, "USE TEMP B-TREE FOR ORDER BY", "query should not filesort; plan was:\n"+planStr)
 	})
 }
 


### PR DESCRIPTION
## Problem

The pull-consumer endpoint `GET /channel/{channel}/consumer/{consumer}/queued-jobs`
degrades to **O(backlog)** and returns **HTTP 504** (60s gateway cap) once a consumer
accumulates a large QUEUED backlog. This took down `shamwow-asset-modified-consumer` on
the highest-volume channel (`eb_cmp_asset_modified`).

**Why it's an unrecoverable death spiral:** the fetch endpoint is the *only* drain for a
healthy pull consumer's QUEUED jobs (the recovery path `GetJobsReadyForInflightSince` only
auto-dispatches when `retryAttemptCount >= threshold` or the consumer is not pull-based).
Once fetch 504s: nothing leaves QUEUED → producers keep adding → the set grows → the query
gets slower → guaranteed 504 forever. There is no API endpoint to purge QUEUED jobs, so a
consumer over the line cannot be recovered through the API.

## Root cause

`GetPrioritizedJobsForConsumer` (`storage/deliveryjobrepo.go`) runs:

```sql
SELECT ... FROM job WHERE consumerId like ? AND status = ?
ORDER BY priority DESC, createdAt DESC, id DESC LIMIT ?
```

`priority` was added to `job` in migration 000006, but **no index covers it**. The best
existing index `jobs_by_consumer (consumerId, status, id, createdAt)` satisfies the filter
but not the sort, so the DB **filesorts the consumer's entire QUEUED set before `LIMIT`** —
cost scales with backlog depth, not page size. That's why adding `limit` doesn't help and
why only the busiest channel crosses 60s.

### Before / after `EXPLAIN QUERY PLAN` (SQLite test engine, real schema)

| Scenario | Plan |
|---|---|
| Before (existing indexes) | `SCAN job` + `USE TEMP B-TREE FOR ORDER BY` (filesort) |
| New index, still `LIKE` | `... USING COVERING INDEX` + **still `USE TEMP B-TREE`** ❌ |
| New index + `=` | `SEARCH job USING COVERING INDEX (consumerId=? AND status=?)` — **no temp b-tree** ✅ |

**Key detail:** `consumerId like ?` is treated as a *range*, which defeats index-ordered
`ORDER BY` on the trailing columns — the filesort survives even with the perfect index.
MySQL's optimizer behaves the same way (range on the leading column breaks the ordering).
`consumerId` is always an exact xid, so the fix needs **both** the index **and** `=`.

## Fix

Two parts, both required to eliminate the filesort:

1. **Migration `000013_add_prioritized_jobs_index`** — composite index
   `job_consumer_status_priority (consumerId, status, priority DESC, createdAt DESC, id DESC)`.
   MySQL 8.0 (confirmed via `utf8mb4_0900_ai_ci`) supports descending index columns, already
   relied on by migration 000011.
2. **`consumerId like ?` → `consumerId = ?`** in the query (semantically identical for xids).

### Downtime-safe / idempotent migration
Migrations run **synchronously at app startup under a lock** (`storage/rdbms.go`), so a
blocking `CREATE INDEX` on the large prod `job` table could stall pod startup / trip the
startupProbe. The migration is therefore **idempotent**: it checks `information_schema` and
creates the index only if absent (online `ALGORITHM=INPLACE, LOCK=NONE`), otherwise it's an
instant no-op. Recommended rollout (see `docs/runbooks/drain-queued-backlog.md`):

1. DBA builds the index **out-of-band first** (`gh-ost` / `pt-online-schema-change` / online
   `INPLACE, LOCK=NONE`) — non-blocking, throttled on replica lag → **zero downtime**.
2. Deploy the code → startup migration sees the index exists → no-op.
3. Dev/test/fresh DBs (`CREATE INDEX IF NOT EXISTS`) create it instantly — self-healing.

### Index build cost / risk
Adding a secondary index to a large InnoDB table is `INPLACE, LOCK=NONE` (concurrent
DML allowed) but still consumes IO/CPU and can add replica lag during the build; run in a
low-traffic window or use `gh-ost`. It's additive and can be rolled forward independently of
the code and of the backlog drain.

## Secondary hardening
The endpoint already applies a sane server-side page size (default 25, max 100 —
`controllers/job.go`); no unbounded count/aggregate is on this path. No semantic change made.

## Tests
- Added `TestGetPrioritizedJobsForConsumer/UsesPrioritizedIndexNoFilesort`: runs
  `EXPLAIN QUERY PLAN` on the **actual** query (bound to the shared `prioritizedJobsForConsumerQuery`
  const) and asserts it uses `job_consumer_status_priority` with no filesort. Verified it fails
  if the query is reverted to `like` (falls back to `job_status_created_id` + temp b-tree).
- `go test ./storage/... ./controllers/...` green.

## Operational follow-up (not code)
`docs/runbooks/drain-queued-backlog.md` documents draining the already-accumulated backlog:
resolve the internal `consumer.id`, then a scoped **batched `DELETE ... WHERE consumerId=? AND
status=1001`** (QUEUED=**1001**, not 1000). Must be run on **both** broker deployments (AWS +
GCP, independent DBs); dropped events backfill out-of-band. **Requires DBA/maintainer sign-off —
do not run unreviewed on shared prod.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)