### PR TITLE
feat: make startup DB migrations opt-in (default off)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /etc/ssl/c
 WORKDIR /
 COPY --from=build-env /go/src/github.com/newscred/webhook-broker/webhook-broker /webhook-broker
 COPY --from=build-env /go/src/github.com/newscred/webhook-broker/migration /migration
-CMD [ "webhook-broker", "-migrate", "/migration/sqls/" ]
+CMD [ "webhook-broker", "-migrate", "/migration/sqls/", "-run-migration" ]

--- a/config/cliconfig.go
+++ b/config/cliconfig.go
@@ -29,6 +29,7 @@ type CommandOption string
 type CLIConfig struct {
 	ConfigPath             string
 	MigrationSource        string
+	RunMigration           bool
 	StopOnConfigChange     bool
 	DoNotWatchConfigChange bool
 	Command                CommandOption
@@ -56,9 +57,13 @@ func (conf *CLIConfig) SetCommandIfValid(command string) error {
 	}
 }
 
-// IsMigrationEnabled returns whether migration is enabled
+// IsMigrationEnabled returns whether migrations should be applied at startup.
+// Applying migrations is opt-in: it requires both a migration source (-migrate) and
+// the explicit -run-migration flag. This keeps pod startup decoupled from DDL so a
+// blocking migration cannot crashloop the fleet; migrations are run deliberately
+// out-of-band (see docs/runbooks/run-migrations-out-of-band.md).
 func (conf *CLIConfig) IsMigrationEnabled() bool {
-	return len(conf.MigrationSource) > 0
+	return conf.RunMigration && len(conf.MigrationSource) > 0
 }
 
 // NotifyOnConfigFileChange registers a callback function for changes to ConfigPath; it calls the `callback` when a change is detected

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -510,14 +510,25 @@ func TestGetConfigurationFromCLIConfig(t *testing.T) {
 }
 
 func TestMigrationEnabled(t *testing.T) {
-	t.Run("MigrationEnabled", func(t *testing.T) {
+	t.Run("NoSourceNoRunFlag", func(t *testing.T) {
 		t.Parallel()
 		cliConfig := &CLIConfig{}
 		assert.False(t, cliConfig.IsMigrationEnabled())
 	})
-	t.Run("MigrationDisabled", func(t *testing.T) {
+	t.Run("SourceWithoutRunFlag", func(t *testing.T) {
 		t.Parallel()
+		// Migrations are opt-in: a source alone must not enable startup migrations.
 		cliConfig := &CLIConfig{MigrationSource: "file:///test/"}
+		assert.False(t, cliConfig.IsMigrationEnabled())
+	})
+	t.Run("RunFlagWithoutSource", func(t *testing.T) {
+		t.Parallel()
+		cliConfig := &CLIConfig{RunMigration: true}
+		assert.False(t, cliConfig.IsMigrationEnabled())
+	})
+	t.Run("SourceWithRunFlag", func(t *testing.T) {
+		t.Parallel()
+		cliConfig := &CLIConfig{MigrationSource: "file:///test/", RunMigration: true}
 		assert.True(t, cliConfig.IsMigrationEnabled())
 	})
 }

--- a/docker-compose.integration-test.yaml
+++ b/docker-compose.integration-test.yaml
@@ -27,7 +27,7 @@ services:
     container_name: ibroker
     volumes:
       - ./webhook-broker-integration-test.cfg:/webhook-broker.cfg
-    command: ["./webhook-broker", "-migrate", "./migration/sqls/"]
+    command: ["./webhook-broker", "-migrate", "./migration/sqls/", "-run-migration"]
     depends_on:
       mysql8:
         condition: service_healthy
@@ -49,7 +49,7 @@ services:
     container_name: ibroker-hmac
     volumes:
       - ./webhook-broker-integration-test-hmac.cfg:/webhook-broker.cfg
-    command: ["./webhook-broker", "-migrate", "./migration/sqls/"]
+    command: ["./webhook-broker", "-migrate", "./migration/sqls/", "-run-migration"]
     depends_on:
       ibroker:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - "18181:8080"
     volumes:
       - ./webhook-broker-dc.cfg:/webhook-broker.cfg
-    command: ["./webhook-broker", "-migrate", "./migration/sqls/"]
+    command: ["./webhook-broker", "-migrate", "./migration/sqls/", "-run-migration"]
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/runbooks/run-migrations-out-of-band.md
+++ b/docs/runbooks/run-migrations-out-of-band.md
@@ -1,0 +1,97 @@
+# Runbook: Running DB migrations out-of-band
+
+## Why migrations no longer run at pod startup
+
+Migrations are **opt-in**. The broker only applies migrations at startup when **both**:
+
+- `-migrate <source>` is set (where the migration SQL lives), **and**
+- `-run-migration` is passed (the explicit apply flag).
+
+The production Helm manifest passes only `-migrate /migration/sqls/` (see
+`deploy-pkg/webhook-broker-chart/templates/deployment.yaml`), so **normal pods do not
+apply migrations**. This is deliberate.
+
+### The failure this prevents
+
+Migrations run synchronously at startup under an application-level `GET_LOCK`
+(`storage/rdbms.go` `runMigration`). A migration that issues DDL on a large table (e.g.
+`CREATE INDEX` on `job`) can get stuck **`Waiting for table metadata lock`** behind a
+long-lived MDL holder. A DDL *waiting* for its exclusive metadata lock head-of-line-blocks
+every subsequent query on that table — freezing the table without holding any usable lock —
+while still holding the migration `GET_LOCK`. Every other pod then fails startup with
+`can't acquire lock` → `could not start http service` and crashloops fleet-wide.
+
+Because the image tag is mutable (`pullPolicy: Always`), shipping an image whose default is
+"do not migrate" stops that crashloop on **every** cluster (AWS + all GCP) with a single
+image deploy — no per-cluster manifest edits.
+
+## How to apply migrations deliberately
+
+Run the broker binary with **both** flags, as a **single** short-lived pod (the `GET_LOCK`
+serializes it, but only run one at a time to keep it obvious), during a low-traffic window,
+using the **same image** already deployed:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: webhook-broker-migrate
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: webhook-broker
+      containers:
+        - name: migrate
+          image: <same repository:tag as the running broker>
+          command: ["/webhook-broker"]
+          args: ["-migrate", "/migration/sqls/", "-run-migration", "-config", "/app-config/webhook-broker.cfg"]
+          volumeMounts:
+            - name: conf-vol
+              mountPath: /app-config/
+      volumes:
+        - name: conf-vol
+          # same config source (Secret/ConfigMap) the Deployment mounts
+```
+
+Before running, make sure the migration will not itself wedge on an MDL:
+
+- **Clear long-lived holders first.** Check `SHOW PROCESSLIST` for long-running queries or
+  idle-in-transaction sessions on the target table and resolve them; drain any runaway
+  backlog (see [`drain-queued-backlog.md`](./drain-queued-backlog.md)).
+- Prefer building heavy indexes **out-of-band** (gh-ost / pt-online-schema-change /
+  `ALGORITHM=INPLACE, LOCK=NONE`) and let the migration be an idempotent no-op — migration
+  `000013_add_prioritized_jobs_index` is written to detect an already-built index and skip.
+
+Watch the Job's logs to confirm the migration completed, then delete the Job.
+
+## Incident recovery order (crashloop from a wedged startup migration)
+
+1. **Deploy the migrations-opt-in image** so pods stop attempting migrations at startup and
+   come up healthy. (This does **not** unwedge the DB.)
+2. **Unwedge the DB — maintainer/DBA, per database (AWS and GCP are independent):** find the
+   stuck DDL in `SHOW PROCESSLIST` (`State: Waiting for table metadata lock`, on `job`) and
+   `KILL <pid>`. This releases the table MDL, unblocks the query pile-up, and releases the
+   migration `GET_LOCK`.
+3. **Build the index safely out-of-band** on each DB (see
+   [`drain-queued-backlog.md`](./drain-queued-backlog.md) Part A).
+4. **Reconcile migration bookkeeping.** golang-migrate tracks state in `schema_migrations`
+   (`version`, `dirty`). A killed in-band migration leaves `dirty = 1`. Once the index
+   exists, clear the flag and align the version:
+   ```sql
+   -- Verify current state first.
+   SELECT version, dirty FROM schema_migrations;
+   -- After confirming the 000013 index is present:
+   UPDATE schema_migrations SET dirty = 0 WHERE dirty = 1;
+   ```
+   Then run the migration Job (above) so any remaining migrations apply cleanly, or confirm
+   `version` already reflects 000013.
+
+## Fresh / empty environments (important)
+
+Because startup no longer migrates, a **brand-new or empty database has no schema**. The
+broker's `InitAppData` needs the `app` table to exist, so a first-boot broker against an
+empty DB will fail. **Run the migration Job first**, then start/scale up the broker.
+
+<!-- Generated with assistance from Claude AI -->

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ var (
 		commandString := flags.String("command", string(config.BrokerCMD), "What operation this process is supposed to do")
 		flags.StringVar(&conf.ConfigPath, "config", "", "Config file location")
 		flags.StringVar(&conf.MigrationSource, "migrate", "", "Migration source folder")
+		flags.BoolVar(&conf.RunMigration, "run-migration", false, "Apply DB migrations at startup (requires -migrate). Default off; run migrations out-of-band instead")
 		flags.BoolVar(&conf.StopOnConfigChange, "stop-on-conf-change", false, "Restart internally on -config change if this flag is absent")
 		flags.BoolVar(&conf.DoNotWatchConfigChange, "do-not-watch-conf-change", false, "Do not watch config change")
 

--- a/main_test.go
+++ b/main_test.go
@@ -118,7 +118,7 @@ func TestMainFunc(t *testing.T) {
 			return nil, errors.New("No App Error")
 		}
 		exit = panicExit
-		os.Args = []string{"webhook-broker", "-migrate", "./migration/sqls/"}
+		os.Args = []string{"webhook-broker", "-migrate", "./migration/sqls/", "-run-migration"}
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -184,7 +184,7 @@ func TestMainFunc(t *testing.T) {
 		log.Logger = log.Output(&buf)
 		oldArgs := os.Args
 		os.WriteFile(configFilePath, []byte(notificationInitialContent), 0644)
-		os.Args = []string{"webhook-broker", "-migrate", "./migration/sqls/", "-config", configFilePath}
+		os.Args = []string{"webhook-broker", "-migrate", "./migration/sqls/", "-run-migration", "-config", configFilePath}
 		oldNotify := controllers.NotifyOnInterrupt
 		controllers.NotifyOnInterrupt = configChangeRestartMainFnBreaker
 		defer func() {
@@ -221,7 +221,7 @@ func TestMainFunc(t *testing.T) {
 		}
 		os.WriteFile(configFilePath2, []byte(notificationInitialContent), 0644)
 		oldArgs := os.Args
-		os.Args = []string{"webhook-broker", "-migrate", "./migration/sqls/", "-config", configFilePath2, "-stop-on-conf-change"}
+		os.Args = []string{"webhook-broker", "-migrate", "./migration/sqls/", "-run-migration", "-config", configFilePath2, "-stop-on-conf-change"}
 		defer func() {
 			os.Args = oldArgs
 		}()
@@ -362,9 +362,18 @@ func TestParseArgs(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Equal(t, err, ErrMigrationSrcNotDir)
 	})
+	t.Run("MigrationSourceWithoutRunMigration", func(t *testing.T) {
+		t.Parallel()
+		// -migrate resolves the source but migrations stay opt-in: without -run-migration
+		// they are not applied at startup.
+		cliConfig, _, err := parseArgs("webhook-broker", []string{"-migrate", "./migration"})
+		assert.Nil(t, err)
+		assert.False(t, cliConfig.IsMigrationEnabled())
+		assert.Equal(t, "file://"+absPath, cliConfig.MigrationSource)
+	})
 	t.Run("ValidMigrationSourceAbs", func(t *testing.T) {
 		t.Parallel()
-		cliConfig, _, err := parseArgs("webhook-broker", []string{"-migrate", "./migration"})
+		cliConfig, _, err := parseArgs("webhook-broker", []string{"-migrate", "./migration", "-run-migration"})
 		assert.Nil(t, err)
 		assert.True(t, cliConfig.IsMigrationEnabled())
 		assert.Equal(t, "file://"+absPath, cliConfig.MigrationSource)
@@ -372,7 +381,7 @@ func TestParseArgs(t *testing.T) {
 	})
 	t.Run("ValidMigrationSourceRelative", func(t *testing.T) {
 		t.Parallel()
-		cliConfig, _, err := parseArgs("webhook-broker", []string{"-migrate", absPath})
+		cliConfig, _, err := parseArgs("webhook-broker", []string{"-migrate", absPath, "-run-migration"})
 		assert.Nil(t, err)
 		assert.True(t, cliConfig.IsMigrationEnabled())
 		assert.Equal(t, "file://"+absPath, cliConfig.MigrationSource)


### PR DESCRIPTION
## Problem

Migrations run **synchronously at pod startup** under a `GET_LOCK` (golang-migrate, `storage/rdbms.go` `runMigration`). A migration that issues DDL on a large table — e.g. migration 000013's `CREATE INDEX` on `job` — can get stuck `Waiting for table metadata lock` behind a long-lived MDL holder. A DDL *waiting* for its exclusive metadata lock head-of-line-blocks every subsequent query on that table (freezing it without holding any usable lock) while still holding the migration `GET_LOCK`. Every other pod then fails startup with `can't acquire lock` → `could not start http service` and **crashloops fleet-wide** (observed on AWS and GCP).

Because the image tag is mutable (`pullPolicy: Always`), we need a fix that ships as a **single image deploy** — no per-cluster manifest surgery. The chart args (`-migrate /migration/sqls/`) are baked into the already-deployed manifest, so the lever has to be the code default, not the args.

## Change

Make applying migrations **opt-in**. Decouple:
- **where migrations live** — `-migrate <path>` (unchanged), from
- **whether they're applied at startup** — new `-run-migration` bool, **default `false`**.

`IsMigrationEnabled()` now requires **both**. Production args carry only `-migrate`, so the new image stops startup migrations on every cluster with one deploy. Migrations become a deliberate out-of-band action (a one-off Job / explicit flag).

### What's included
- `config/cliconfig.go` — `RunMigration` field; `IsMigrationEnabled()` = `RunMigration && len(MigrationSource) > 0`.
- `main.go` — `-run-migration` flag (default off).
- `Dockerfile`, `docker-compose.yaml`, `docker-compose.integration-test.yaml` — add `-run-migration` so local dev / integration tests still build schema (prod overrides `args`, so it stays off there).
- **`deploy-pkg/webhook-broker-chart/templates/deployment.yaml` intentionally unchanged** — omitting the flag is exactly what disables prod startup migrations via the image alone.
- `docs/runbooks/run-migrations-out-of-band.md` — the new opt-in model, applying migrations via a one-off single-pod Job on the same image, crashloop recovery order, and the fresh-empty-DB caveat.
- Tests updated for the new opt-in semantics (`config/config_test.go`, `main_test.go`).

## Behavioral change / risk

- **Default flips:** migrations no longer apply on startup anywhere. Existing clusters already have schema → they start fine (that's the fix). **Fresh/empty environments must run the migration Job first** (schema + `app` table for `InitAppData`), or first boot fails — documented in the runbook.
- Applying a real migration now needs two flags (`-migrate` + `-run-migration`) — explicit, in flag help and the runbook.

## Not in scope

- Does **not** unwedge an already-stuck DB — the stuck `CREATE INDEX` still needs a `KILL` per database (maintainer/DBA action; see runbook).
- The scoped `lock_wait_timeout` guard on migration DDL is left as a possible follow-up.

## Testing

- `go test -timeout 120s -mod=readonly ./... -short` — all packages green.
- `go vet ./config/ .` clean; `go build ./...` OK.
- `IsMigrationEnabled()` verified false with `-migrate` alone, true only with both flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)