### PR TITLE
fix: return conditional-failed error on 412, not media-type

### DIFF
--- a/controllers/consumer.go
+++ b/controllers/consumer.go
@@ -102,7 +102,7 @@ func (controller *ConsumerController) Delete(w http.ResponseWriter, r *http.Requ
 	switch err {
 	case nil:
 		if validRequest := isConditionalUpdateCalled(w, r, consumer); !validRequest {
-			writePreconditionFailed(w)
+			return
 		} else if delErr := controller.ConsumerRepo.Delete(consumer); delErr != nil {
 			writeErr(w, delErr)
 		} else {

--- a/controllers/consumer_test.go
+++ b/controllers/consumer_test.go
@@ -270,6 +270,7 @@ func TestConsumerDelete(t *testing.T) {
 		rr := httptest.NewRecorder()
 		testRouter.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusPreconditionFailed, rr.Code)
+		assert.Equal(t, ErrConditionalFailed.Error(), rr.Body.String())
 	})
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
@@ -578,6 +579,7 @@ func TestConsumerPut(t *testing.T) {
 		rr := httptest.NewRecorder()
 		testRouter.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusPreconditionFailed, rr.Code)
+		assert.Equal(t, ErrConditionalFailed.Error(), rr.Body.String())
 	})
 	t.Run("500", func(t *testing.T) {
 		t.Parallel()

--- a/controllers/producer_test.go
+++ b/controllers/producer_test.go
@@ -233,6 +233,7 @@ func TestProducerPut(t *testing.T) {
 		rr := httptest.NewRecorder()
 		testRouter.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusPreconditionFailed, rr.Code)
+		assert.Equal(t, ErrConditionalFailed.Error(), rr.Body.String())
 	})
 	t.Run("500", func(t *testing.T) {
 		t.Parallel()

--- a/controllers/router.go
+++ b/controllers/router.go
@@ -35,7 +35,7 @@ var (
 	ControllerInjector = wire.NewSet(ConfigureAPI, NewRouter, NewStatusController, NewProducersController, NewProducerController, NewChannelController, NewChannelsController, NewConsumerController, NewConsumersController, NewJobsController, NewJobController, NewBroadcastController, NewMessageController, NewMessagesController, NewMessagesStatusController, NewDLQController, NewJobRequeueController, NewJobStatusController, NewScheduledMessageController, NewScheduledMessagesController, NewDLQStatusController, NewDLQPurgeController, NewDeadJobDeleteController, wire.Struct(new(Controllers), "StatusController", "ProducersController", "ProducerController", "ChannelController", "ConsumerController", "ConsumersController", "JobsController", "JobController", "BroadcastController", "MessageController", "MessagesController", "DLQController", "ChannelsController", "MessagesStatusController", "JobRequeueController", "JobStatusController", "ScheduledMessageController", "ScheduledMessagesController", "DLQStatusController", "DLQPurgeController", "DeadJobDeleteController", "MetricsHandler"))
 	// ErrUnsupportedMediaType is returned when client does not provide appropriate `Content-Type` header
 	ErrUnsupportedMediaType = errors.New("Media type not supported")
-	// ErrConditionalFailed is returned when update is missing `If-Unmodified-Since` header
+	// ErrConditionalFailed is returned when an update's `If-Unmodified-Since` header does not match the resource's last-modified time
 	ErrConditionalFailed = errors.New("Update failed due to mismatch of `If-Unmodified-Since` header value")
 	// ErrNotFound is returned when resource is not found
 	ErrNotFound = errors.New("Request resource not found")
@@ -321,7 +321,7 @@ func writeUnsupportedMediaType(w http.ResponseWriter) {
 }
 
 func writePreconditionFailed(w http.ResponseWriter) {
-	writeStatus(w, http.StatusPreconditionFailed, ErrUnsupportedMediaType)
+	writeStatus(w, http.StatusPreconditionFailed, ErrConditionalFailed)
 }
 
 func writeStatus(w http.ResponseWriter, code int, err error) {


### PR DESCRIPTION
`writePreconditionFailed` wrote `ErrUnsupportedMediaType` ("Media type not supported"), so every 412 `If-Unmodified-Since` precondition failure returned a body pointing at Content-Type. Switches it to the previously-unused `ErrConditionalFailed` and fixes that var's stale doc comment (said "missing header"; the 412 case is a mismatch — a missing header is a 400).

Affects all precondition-guarded endpoints (consumer/producer/channel/job/broadcast). Status code is unchanged (still 412); existing tests assert only on the code. `go build ./controllers/` and `go test ./controllers/ -run 'Consumer|Producer'` pass locally.