### PR TITLE
remove concurrent map write from MemoryCache.Get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,11 @@ time-test:
 
 ci-test:
 	go test -timeout 45s -mod=readonly -v ./... -short
+	go test -v -race -timeout 45s -mod=readonly -run '_Race' ./...
 
 test:
 	go test -v -timeout 45s -mod=readonly ./...
+	go test -v -race -timeout 45s -mod=readonly -run '_Race' ./...
 
 install: build
 	go install -mod=readonly

--- a/storage/memcache.go
+++ b/storage/memcache.go
@@ -46,8 +46,6 @@ func (c *MemoryCache[K, V]) Get(key K) (V, bool) {
 		if c.ttl == 0 || time.Now().Before(item.Expiration) { // Check for expiration
 			return item.Value, true
 		}
-		// Remove expired items since they aren't going to be returned
-		delete(c.cache, key)
 	}
 	var emptyValue V
 	return emptyValue, false

--- a/storage/memcache_test.go
+++ b/storage/memcache_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -67,3 +68,23 @@ func TestMemoryCache(t *testing.T) {
 	})
 }
 
+func TestMemoryCache_Race(t *testing.T) {
+	t.Run("ConcurrentGetExpired", func(t *testing.T) {
+		cache := NewMemoryCache[string, int](time.Hour)
+		defer cache.Close()
+
+		// Insert an already-expired item, then read it from many goroutines at once.
+		cache.cache["k"] = &CacheItem[string, int]{Value: 1, Expiration: time.Now().Add(-time.Minute)}
+
+		var wg sync.WaitGroup
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, ok := cache.Get("k")
+				assert.False(t, ok)
+			}()
+		}
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
## Problem

`MemoryCache.Get` held only a read lock (`RLock`) but deleted expired items directly from the map. Read locks permit concurrent holders, so two `Get` calls on the same expired key could `delete` the map at the same time, causing `fatal error: concurrent map writes`.

## Fix

Remove the delete from `Get` entirely. `Get` now only reads — expired entries are cleaned up by the background `cleanup()` goroutine (and overwritten on `Set`), so the read path never mutates the map. This keeps `Get` on the cheap read lock without any write hazard.

## Tests

- Added `TestMemoryCache_Race` (`ConcurrentGetExpired`): reads an expired key from many goroutines at once. Against the buggy version this fails under `-race`.
- Adopted a `_Race` naming convention for race-sensitive tests and wired `make test` / `make ci-test` to run them under `-race`.

## Verify

```
go test -race -run '_Race' ./storage/
```