### PR TITLE
fix(build): skip -race on arm64 to avoid QEMU ThreadSanitizer failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ UNAME_S := $(shell uname -s)
 
 ARCH := $(shell arch)
 
+RACE := -race
+ifeq ($(ARCH),aarch64)
+RACE :=
+endif
+ifeq ($(ARCH),arm64)
+RACE :=
+endif
+
 OS := $(shell test -f /etc/os-release && cat /etc/os-release | grep '^NAME' | sed -e 's/NAME="\(.*\)"/\1/g')
 
 all: clean os-deps dep-tools deps test build
@@ -98,11 +106,11 @@ time-test:
 
 ci-test:
 	go test -timeout 45s -mod=readonly -v ./... -short
-	go test -v -race -timeout 45s -mod=readonly -run '_Race' ./...
+	go test -v $(RACE) -timeout 45s -mod=readonly -run '_Race' ./...
 
 test:
 	go test -v -timeout 45s -mod=readonly ./...
-	go test -v -race -timeout 45s -mod=readonly -run '_Race' ./...
+	go test -v $(RACE) -timeout 45s -mod=readonly -run '_Race' ./...
 
 install: build
 	go install -mod=readonly


### PR DESCRIPTION
## Problem

The multi-arch container build fails on the \`linux/arm64\` platform:

\`\`\`
FATAL: ThreadSanitizer: unsupported VMA range
FATAL: Found 47 - Supported 48
\`\`\`

Cause chain:
- \`container-build.yml\` builds \`linux/amd64,linux/arm64\` with QEMU emulation.
- The \`Dockerfile\` runs \`make test\`.
- \`make test\` runs \`go test -race\`.
- \`-race\` uses ThreadSanitizer. Under QEMU-emulated arm64 the VMA range is 47-bit, but the arm64 TSan runtime expects 48-bit. The mismatch is fatal.

The Go race detector does not work under QEMU user-mode emulation of arm64. This is a known toolchain limitation, not a code bug.

## Change

Gate \`-race\` behind a \`RACE\` variable in the \`Makefile\`, cleared to empty when \`ARCH\` is \`aarch64\` or \`arm64\`. Applied to both \`test\` and \`ci-test\` targets.

- On arm64, the \`_Race\` tests still run, without the detector.
- On amd64, behavior is unchanged. The native gate (\`build.yml\` \`ci-test\`) still runs with \`-race\`.

## Verification

- \`make -n test\` on arm64 shows the \`-race\` flag is dropped; on amd64 it stays.