### PR TITLE
refactor(storage): remove redundant mutex from cached repositories

### DIFF
--- a/storage/channelrepo.go
+++ b/storage/channelrepo.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"database/sql"
-	"sync"
 	"time"
 
 	"github.com/newscred/webhook-broker/storage/data"
@@ -14,7 +13,6 @@ type PseudoChannelRepository ChannelRepository
 type CachedChannelRepository struct {
 	delegate ChannelRepository
 	cache    *MemoryCache[string, *data.Channel]
-	mutex    sync.RWMutex
 }
 
 // NewCachedChannelRepository creates a new CachedChannelRepository.
@@ -27,12 +25,9 @@ func NewCachedChannelRepository(delegate PseudoChannelRepository, ttl time.Durat
 
 // Get retrieves a channel by ID, first checking the cache.
 func (repo *CachedChannelRepository) Get(channelID string) (*data.Channel, error) {
-	repo.mutex.RLock()
 	if item, ok := repo.cache.Get(channelID); ok {
-		repo.mutex.RUnlock()
 		return item, nil // Cache hit
 	}
-	repo.mutex.RUnlock()
 
 	// Cache miss; fetch from the underlying repository
 	channel, err := repo.delegate.Get(channelID)
@@ -40,9 +35,7 @@ func (repo *CachedChannelRepository) Get(channelID string) (*data.Channel, error
 		return channel, err
 	}
 
-	repo.mutex.Lock()
 	repo.cache.Set(channelID, channel) // Cache the channel
-	repo.mutex.Unlock()
 
 	return channel, nil
 }
@@ -52,9 +45,7 @@ func (repo *CachedChannelRepository) Store(channel *data.Channel) (*data.Channel
 
 	channel, err := repo.delegate.Store(channel)
 	if err == nil {
-		repo.mutex.Lock()
 		repo.cache.Delete(channel.ChannelID)
-		repo.mutex.Unlock()
 	}
 	return channel, err
 }

--- a/storage/consumerrepo.go
+++ b/storage/consumerrepo.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"database/sql"
 	"time"
-	"sync"
 
 	"github.com/newscred/webhook-broker/storage/data"
 )
@@ -138,7 +137,6 @@ func NewConsumerRepository(db *sql.DB, channelRepo ChannelRepository) PseudoCons
 type CachedConsumerRepository struct {
 	delegate ConsumerRepository
 	cache    *MemoryCache[string, *data.Consumer]
-	mutex    sync.RWMutex
 }
 
 // NewCachedConsumerRepository creates a new CachedConsumerRepository.
@@ -152,12 +150,9 @@ func NewCachedConsumerRepository(delegate PseudoConsumerRepository, ttl time.Dur
 // Get retrieves a consumer by ID, first checking the cache.
 func (repo *CachedConsumerRepository) Get(channelID string, consumerID string) (*data.Consumer, error) {
 	cacheKey := channelID + ":" + consumerID  // Create a composite key
-	repo.mutex.RLock()
 	if item, ok := repo.cache.Get(cacheKey); ok {
-		repo.mutex.RUnlock()
 		return item, nil // Cache hit
 	}
-	repo.mutex.RUnlock()
 
 	// Cache miss; fetch from the underlying repository
 	consumer, err := repo.delegate.Get(channelID, consumerID)
@@ -165,9 +160,7 @@ func (repo *CachedConsumerRepository) Get(channelID string, consumerID string) (
 		return consumer, err
 	}
 
-	repo.mutex.Lock()
 	repo.cache.Set(cacheKey, consumer) // Cache the consumer
-	repo.mutex.Unlock()
 	return consumer, nil
 }
 
@@ -175,21 +168,16 @@ func (repo *CachedConsumerRepository) Get(channelID string, consumerID string) (
 // GetByID retrieves a consumer by its ID from the cache or underlying repository
 func (repo *CachedConsumerRepository) GetByID(id string) (*data.Consumer, error) {
 
-	repo.mutex.RLock()
 	if item, ok := repo.cache.Get(id); ok {
-		repo.mutex.RUnlock()
 		return item, nil //Cache Hit
 	}
-	repo.mutex.RUnlock()
 
 	consumer, err := repo.delegate.GetByID(id)
 	if err != nil {
 		return nil, err
 	}
 
-	repo.mutex.Lock()
 	repo.cache.Set(id, consumer)
-	repo.mutex.Unlock()
 
 	return consumer, nil
 }
@@ -199,10 +187,8 @@ func (repo *CachedConsumerRepository) GetByID(id string) (*data.Consumer, error)
 func (repo *CachedConsumerRepository) Store(consumer *data.Consumer) (*data.Consumer, error) {
 	consumer, err := repo.delegate.Store(consumer)
 	if err == nil {
-		repo.mutex.Lock()
 		repo.cache.Delete(consumer.GetChannelIDSafely() + ":" + consumer.ConsumerID)
 		repo.cache.Delete(consumer.ID.String())
-		repo.mutex.Unlock()
 	}
 	return consumer, err
 }
@@ -211,10 +197,8 @@ func (repo *CachedConsumerRepository) Store(consumer *data.Consumer) (*data.Cons
 func (repo *CachedConsumerRepository) Delete(consumer *data.Consumer) error {
 	err := repo.delegate.Delete(consumer)
 	if err == nil {
-		repo.mutex.Lock()
 		repo.cache.Delete(consumer.GetChannelIDSafely() + ":" + consumer.ConsumerID)
 		repo.cache.Delete(consumer.ID.String())
-		repo.mutex.Unlock()
 	}
 	return err
 }

--- a/storage/producerrepo.go
+++ b/storage/producerrepo.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"database/sql"
-	"sync"
 	"time"
 
 	"github.com/newscred/webhook-broker/storage/data"
@@ -91,7 +90,6 @@ func NewProducerRepository(db *sql.DB) PseudoProducerRepository {
 type CachedProducerRepository struct {
 	delegate ProducerRepository
 	cache    *MemoryCache[string, *data.Producer]
-	mutex    sync.RWMutex
 }
 
 // NewCachedProducerRepository creates a new CachedProducerRepository.
@@ -104,12 +102,9 @@ func NewCachedProducerRepository(delegate PseudoProducerRepository, ttl time.Dur
 
 // Get retrieves a producer by ID, first checking the cache.
 func (repo *CachedProducerRepository) Get(producerID string) (*data.Producer, error) {
-	repo.mutex.RLock()
 	if item, ok := repo.cache.Get(producerID); ok {
-		repo.mutex.RUnlock()
 		return item, nil // Cache hit
 	}
-	repo.mutex.RUnlock()
 
 	// Cache miss; fetch from the underlying repository
 	producer, err := repo.delegate.Get(producerID)
@@ -117,9 +112,7 @@ func (repo *CachedProducerRepository) Get(producerID string) (*data.Producer, er
 		return producer, err
 	}
 
-	repo.mutex.Lock()
 	repo.cache.Set(producerID, producer) // Cache the producer
-	repo.mutex.Unlock()
 
 	return producer, nil
 }
@@ -128,9 +121,7 @@ func (repo *CachedProducerRepository) Get(producerID string) (*data.Producer, er
 func (repo *CachedProducerRepository) Store(producer *data.Producer) (*data.Producer, error) {
 	producer, err := repo.delegate.Store(producer)
 	if err == nil {
-		repo.mutex.Lock()
 		repo.cache.Delete(producer.ProducerID)
-		repo.mutex.Unlock()
 	}
 	return producer, err
 }


### PR DESCRIPTION
## What

Remove the `sync.RWMutex` field and all `Lock`/`Unlock` calls from the three cached repository decorators:

- `CachedChannelRepository`
- `CachedProducerRepository`
- `CachedConsumerRepository`

One commit per file.

## Why

`MemoryCache` already guards every operation with its own `RWMutex` (`storage/memcache.go`). The outer mutex protected calls that were already thread-safe.

The outer mutex also did not make the check-then-set sequence in `Get` atomic. The read lock was released before the delegate fetch, so two goroutines can still both miss and both fetch. For `CachedConsumerRepository`, the two-key delete under one lock also buys no invariant — the two keys already diverge freely (`Get` populates only `channel:consumer`, `GetByID` only `id`). The mutex added no correctness.

## Test

- `go build ./storage/` and `go vet ./storage/`: pass.
- `TestCachedChannelRepository`, `TestCachedProducerRepository`, `TestCachedConsumerRepository`: pass.
- Note: `TestGetMessagesByChannel` and `TestGetJobStatusCountsGroupedByConsumer` fail on `main` without this change too. They are pre-existing and unrelated.