### PR TITLE
perf(storage): sort retry sweep on earliestNextAttemptAt so it uses retry_job

### DIFF
--- a/storage/deliveryjobrepo.go
+++ b/storage/deliveryjobrepo.go
@@ -295,11 +295,55 @@ func (djRepo *DeliveryJobDBRepository) GetJobsInflightSince(delta time.Duration)
 	return djRepo.getJobsForStatusAndDelta(data.JobInflight, delta, true)
 }
 
+// readyForInflightJobsQueryBase backs GetJobsReadyForInflightSince (and its plan regression
+// test). It orders and keyset-paginates on earliestNextAttemptAt -- the column the sweep
+// actually filters on -- so `retry_job` (status, earliestNextAttemptAt, id, createdAt) from
+// migration 000003 serves the predicate, the ORDER BY and the LIMIT in a single range seek.
+// The previous shape ordered by createdAt DESC, which made the optimizer prefer
+// job_status_created_id; that index does not contain earliestNextAttemptAt, so every candidate
+// needed a clustered-index row lookup just to be discarded -> a LIMIT 100 read ~190k rows and
+// took ~19s in production. Sorting oldest-due-first is also the correct order for a retry
+// queue; createdAt DESC starved the jobs that had been waiting longest.
+const (
+	// readyForInflightJobsPageSize must stay in sync with the LIMIT_100_SUFFIX used in the ORDER
+	// BY clause; the loop compares against it to detect a short (final) page.
+	readyForInflightJobsPageSize  = 100
+	readyForInflightJobsQueryBase = jobCommonProjection + " FROM job WHERE status = ? AND earliestNextAttemptAt <= ?" +
+		" AND (retryAttemptCount >= ? OR consumerId NOT IN (SELECT id FROM consumer WHERE type = ?))"
+	readyForInflightJobsOrderBy = " ORDER BY earliestNextAttemptAt ASC, id ASC" + string(LIMIT_100_SUFFIX)
+	// The row-value cursor is what keeps the continuation a range seek on retry_job instead of a
+	// post-scan filter; an `enaa > ? OR (enaa = ? AND id > ?)` rewrite is not range-optimizable.
+	readyForInflightJobsCursor         = " AND (earliestNextAttemptAt, id) > (?, ?)"
+	readyForInflightJobsFirstPageQuery = readyForInflightJobsQueryBase + readyForInflightJobsOrderBy
+	readyForInflightJobsNextPageQuery  = readyForInflightJobsQueryBase + readyForInflightJobsCursor + readyForInflightJobsOrderBy
+)
+
 // GetJobsReadyForInflightSince retrieves jobs in queued status and earliestNextAttemptAt < `now`-delta
 func (djRepo *DeliveryJobDBRepository) GetJobsReadyForInflightSince(delta time.Duration, retryThreshold int) []*data.DeliveryJob {
-	query := fmt.Sprintf(`%s (retryAttemptCount >= %d OR consumerId NOT IN (SELECT id FROM consumer WHERE type = %d)) AND`,
-		jobCommonSelectQuery, retryThreshold, data.PullConsumer)
-	return djRepo.getJobsForStatusAndDeltaWithCustomQuery(data.JobQueued, delta, false, query, "")
+	if delta > 0 {
+		delta = -1 * delta
+	}
+	// The boundary is fixed for the whole sweep; recomputing time.Now() per page would move it
+	// underneath an advancing cursor and let rows slip through between pages.
+	dueBy := time.Now().Add(delta)
+	jobs := make([]*data.DeliveryJob, 0)
+	query := readyForInflightJobsFirstPageQuery
+	args := []interface{}{data.JobQueued, dueBy, retryThreshold, data.PullConsumer}
+	for {
+		pageJobs, _, err := djRepo.getJobs(query, nil, nil, args)
+		if err != nil {
+			log.Error().Err(err).Msg("error - could not list jobs ready for inflight")
+			break
+		}
+		jobs = append(jobs, pageJobs...)
+		if len(pageJobs) < readyForInflightJobsPageSize {
+			break
+		}
+		last := pageJobs[len(pageJobs)-1]
+		query = readyForInflightJobsNextPageQuery
+		args = []interface{}{data.JobQueued, dueBy, retryThreshold, data.PullConsumer, last.EarliestNextAttemptAt, last.ID.String()}
+	}
+	return jobs
 }
 
 // GetByID loads the delivery job with specified id if it exists, else returns an error
@@ -424,3 +468,5 @@ func (djRepo *DeliveryJobDBRepository) GetDeadJobCountsSinceCheckpoint(since tim
 func NewDeliveryJobRepository(db *sql.DB, msgRepo MessageRepository, consumerRepo ConsumerRepository) DeliveryJobRepository {
 	return &DeliveryJobDBRepository{db: db, mesageRepository: msgRepo, consumerRepository: consumerRepo}
 }
+
+// Generated with assistance from Claude AI

--- a/storage/deliveryjobrepo.go
+++ b/storage/deliveryjobrepo.go
@@ -295,24 +295,16 @@ func (djRepo *DeliveryJobDBRepository) GetJobsInflightSince(delta time.Duration)
 	return djRepo.getJobsForStatusAndDelta(data.JobInflight, delta, true)
 }
 
-// readyForInflightJobsQueryBase backs GetJobsReadyForInflightSince (and its plan regression
-// test). It orders and keyset-paginates on earliestNextAttemptAt -- the column the sweep
-// actually filters on -- so `retry_job` (status, earliestNextAttemptAt, id, createdAt) from
-// migration 000003 serves the predicate, the ORDER BY and the LIMIT in a single range seek.
-// The previous shape ordered by createdAt DESC, which made the optimizer prefer
-// job_status_created_id; that index does not contain earliestNextAttemptAt, so every candidate
-// needed a clustered-index row lookup just to be discarded -> a LIMIT 100 read ~190k rows and
-// took ~19s in production. Sorting oldest-due-first is also the correct order for a retry
-// queue; createdAt DESC starved the jobs that had been waiting longest.
+// These back GetJobsReadyForInflightSince (and its plan regression test). Ordering and
+// keyset-paginating on earliestNextAttemptAt, with a row-value cursor, is what lets `retry_job`
+// (status, earliestNextAttemptAt, id, createdAt) serve the predicate, the ORDER BY and the LIMIT
+// in one range seek. Ordering on createdAt instead sends the optimizer to job_status_created_id,
+// which lacks earliestNextAttemptAt, so a LIMIT 100 page read ~190k rows and took ~19s in prod.
 const (
-	// readyForInflightJobsPageSize must stay in sync with the LIMIT_100_SUFFIX used in the ORDER
-	// BY clause; the loop compares against it to detect a short (final) page.
-	readyForInflightJobsPageSize  = 100
+	readyForInflightJobsPageSize  = 100 // keep in sync with LIMIT_100_SUFFIX below
 	readyForInflightJobsQueryBase = jobCommonProjection + " FROM job WHERE status = ? AND earliestNextAttemptAt <= ?" +
 		" AND (retryAttemptCount >= ? OR consumerId NOT IN (SELECT id FROM consumer WHERE type = ?))"
-	readyForInflightJobsOrderBy = " ORDER BY earliestNextAttemptAt ASC, id ASC" + string(LIMIT_100_SUFFIX)
-	// The row-value cursor is what keeps the continuation a range seek on retry_job instead of a
-	// post-scan filter; an `enaa > ? OR (enaa = ? AND id > ?)` rewrite is not range-optimizable.
+	readyForInflightJobsOrderBy        = " ORDER BY earliestNextAttemptAt ASC, id ASC" + string(LIMIT_100_SUFFIX)
 	readyForInflightJobsCursor         = " AND (earliestNextAttemptAt, id) > (?, ?)"
 	readyForInflightJobsFirstPageQuery = readyForInflightJobsQueryBase + readyForInflightJobsOrderBy
 	readyForInflightJobsNextPageQuery  = readyForInflightJobsQueryBase + readyForInflightJobsCursor + readyForInflightJobsOrderBy
@@ -323,8 +315,7 @@ func (djRepo *DeliveryJobDBRepository) GetJobsReadyForInflightSince(delta time.D
 	if delta > 0 {
 		delta = -1 * delta
 	}
-	// The boundary is fixed for the whole sweep; recomputing time.Now() per page would move it
-	// underneath an advancing cursor and let rows slip through between pages.
+	// Fixed for the whole sweep; recomputing per page would move the boundary under the cursor.
 	dueBy := time.Now().Add(delta)
 	jobs := make([]*data.DeliveryJob, 0)
 	query := readyForInflightJobsFirstPageQuery

--- a/storage/deliveryjobrepo_test.go
+++ b/storage/deliveryjobrepo_test.go
@@ -372,8 +372,6 @@ func TestStatusBasedJobsListing(t *testing.T) {
 	})
 }
 
-// TestGetJobsReadyForInflightSincePaginates covers the keyset continuation: the sweep must walk
-// past the first LIMIT 100 page and return every due job exactly once.
 func TestGetJobsReadyForInflightSincePaginates(t *testing.T) {
 	djRepo := getDeliverJobRepository()
 	msgRepo := getMessageRepository()
@@ -398,8 +396,7 @@ func TestGetJobsReadyForInflightSincePaginates(t *testing.T) {
 	assert.Nil(t, djRepo.DispatchMessage(message, pageJobs...))
 	defer func() { assert.Nil(t, djRepo.DeleteJobsForMessage(message)) }()
 
-	// Spread earliestNextAttemptAt so the rows straddle several pages of the (earliestNextAttemptAt,
-	// id) cursor rather than all colliding on one timestamp.
+	// Spread earliestNextAttemptAt so the rows straddle pages instead of colliding on one timestamp.
 	pastTime := time.Now().Add(-1 * time.Hour)
 	for index, job := range pageJobs {
 		_, err := testDB.Exec("UPDATE job SET earliestNextAttemptAt = ? WHERE id like ?",
@@ -418,15 +415,11 @@ func TestGetJobsReadyForInflightSincePaginates(t *testing.T) {
 	}
 }
 
-// TestReadyForInflightJobsQueryPlan is a regression guard: the ACTUAL queries used by
-// GetJobsReadyForInflightSince must be served by the retry_job index (migration 000003) with no
-// filesort. Ordering on createdAt instead sends the optimizer to job_status_created_id, which does
-// not carry earliestNextAttemptAt, so every candidate costs a row lookup before being discarded --
-// that is what made this sweep read ~190k rows per LIMIT 100 page in production. These bind to the
-// real query consts, so reverting the ORDER BY or dropping the row-value cursor fails the test.
-// Runs against the SQLite test DB; SQLite reports a filesort as "USE TEMP B-TREE FOR ORDER BY".
-// On SQLite the filesort assertion is the one that catches a regression -- SQLite picks retry_job
-// even for the createdAt ordering and then sorts, whereas MySQL avoids the sort by switching index.
+// Regression guard: the ACTUAL queries used by GetJobsReadyForInflightSince must be served by
+// retry_job with no filesort, else the sweep degrades to ~190k rows per LIMIT 100 page. Binds to
+// the real query consts, so reverting the ORDER BY or the row-value cursor fails the test. Runs
+// on SQLite, which picks retry_job either way but reports the sort as "USE TEMP B-TREE FOR ORDER
+// BY" -- so that assertion, not the index name, is the one that catches a regression here.
 func TestReadyForInflightJobsQueryPlan(t *testing.T) {
 	explain := func(t *testing.T, query string, args ...interface{}) string {
 		rows, err := testDB.Query("EXPLAIN QUERY PLAN "+query, args...)

--- a/storage/deliveryjobrepo_test.go
+++ b/storage/deliveryjobrepo_test.go
@@ -350,6 +350,110 @@ func TestStatusBasedJobsListing(t *testing.T) {
 			assert.True(t, found)
 		}
 	})
+	t.Run("RetryListOrderedByEarliestNextAttemptAt", func(t *testing.T) {
+		thisJobs := djRepo.GetJobsReadyForInflightSince(configuration.RationalDelay, 4)
+		assert.True(t, sort.SliceIsSorted(thisJobs, func(i, j int) bool {
+			return thisJobs[i].EarliestNextAttemptAt.Before(thisJobs[j].EarliestNextAttemptAt)
+		}), "retry sweep must hand back oldest-due-first so long waiting jobs are not starved")
+	})
+	t.Run("RetryListQueryError", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldLogger := log.Logger
+		log.Logger = log.Output(&buf)
+		defer func() { log.Logger = oldLogger }()
+		errString := "sample retry select error"
+		db, mock, _ := sqlmock.New()
+		errRepo := &DeliveryJobDBRepository{db: db}
+		mock.ExpectQuery("FROM job WHERE status").WillReturnError(errors.New(errString))
+		mock.MatchExpectationsInOrder(true)
+		thisJobs := errRepo.GetJobsReadyForInflightSince(configuration.RationalDelay, 4)
+		assert.Equal(t, 0, len(thisJobs))
+		assert.Contains(t, buf.String(), errString)
+	})
+}
+
+// TestGetJobsReadyForInflightSincePaginates covers the keyset continuation: the sweep must walk
+// past the first LIMIT 100 page and return every due job exactly once.
+func TestGetJobsReadyForInflightSincePaginates(t *testing.T) {
+	djRepo := getDeliverJobRepository()
+	msgRepo := getMessageRepository()
+	pageOverflowChannel, err := data.NewChannel("channel-for-retry-paging", "sampletoken")
+	assert.Nil(t, err)
+	pageOverflowChannel.QuickFix()
+	pageOverflowChannel, err = getChannelRepo().Store(pageOverflowChannel)
+	assert.Nil(t, err)
+	jobCount := readyForInflightJobsPageSize + 20
+	pageConsumers := SetupForDeliveryJobTestsWithOptions(&DeliveryJobSetupOptions{IgnoreSettingConsumers: true,
+		ConsumerCount: jobCount, ConsumerIDPrefix: "retry-paging-consumer-", ConsumerChannel: pageOverflowChannel,
+		ConsumerRepo: getConsumerRepo()})
+	assert.Equal(t, jobCount, len(pageConsumers))
+
+	message := getMessageForJob()
+	assert.Nil(t, msgRepo.Create(message))
+	pageJobs := make([]*data.DeliveryJob, 0, jobCount)
+	for _, consumer := range pageConsumers {
+		job, _ := data.NewDeliveryJob(message, consumer)
+		pageJobs = append(pageJobs, job)
+	}
+	assert.Nil(t, djRepo.DispatchMessage(message, pageJobs...))
+	defer func() { assert.Nil(t, djRepo.DeleteJobsForMessage(message)) }()
+
+	// Spread earliestNextAttemptAt so the rows straddle several pages of the (earliestNextAttemptAt,
+	// id) cursor rather than all colliding on one timestamp.
+	pastTime := time.Now().Add(-1 * time.Hour)
+	for index, job := range pageJobs {
+		_, err := testDB.Exec("UPDATE job SET earliestNextAttemptAt = ? WHERE id like ?",
+			pastTime.Add(time.Duration(index)*time.Second), job.ID)
+		assert.Nil(t, err)
+	}
+
+	foundJobs := djRepo.GetJobsReadyForInflightSince(configuration.RationalDelay, 4)
+	assert.Less(t, readyForInflightJobsPageSize, len(foundJobs), "fixture must overflow a single page")
+	seen := make(map[xid.ID]int)
+	for _, job := range foundJobs {
+		seen[job.ID] = seen[job.ID] + 1
+	}
+	for _, job := range pageJobs {
+		assert.Equal(t, 1, seen[job.ID], "job "+job.ID.String()+" must be returned exactly once across pages")
+	}
+}
+
+// TestReadyForInflightJobsQueryPlan is a regression guard: the ACTUAL queries used by
+// GetJobsReadyForInflightSince must be served by the retry_job index (migration 000003) with no
+// filesort. Ordering on createdAt instead sends the optimizer to job_status_created_id, which does
+// not carry earliestNextAttemptAt, so every candidate costs a row lookup before being discarded --
+// that is what made this sweep read ~190k rows per LIMIT 100 page in production. These bind to the
+// real query consts, so reverting the ORDER BY or dropping the row-value cursor fails the test.
+// Runs against the SQLite test DB; SQLite reports a filesort as "USE TEMP B-TREE FOR ORDER BY".
+// On SQLite the filesort assertion is the one that catches a regression -- SQLite picks retry_job
+// even for the createdAt ordering and then sorts, whereas MySQL avoids the sort by switching index.
+func TestReadyForInflightJobsQueryPlan(t *testing.T) {
+	explain := func(t *testing.T, query string, args ...interface{}) string {
+		rows, err := testDB.Query("EXPLAIN QUERY PLAN "+query, args...)
+		assert.NoError(t, err)
+		defer rows.Close()
+		var plan strings.Builder
+		for rows.Next() {
+			var id, parent, notused int
+			var detail string
+			assert.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+			plan.WriteString(detail)
+			plan.WriteString("\n")
+		}
+		assert.NoError(t, rows.Err())
+		return plan.String()
+	}
+	t.Run("FirstPage", func(t *testing.T) {
+		plan := explain(t, readyForInflightJobsFirstPageQuery, data.JobQueued, time.Now(), 4, data.PullConsumer)
+		assert.Contains(t, plan, "retry_job", "query should use the retry index; plan was:\n"+plan)
+		assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY", "query should not filesort; plan was:\n"+plan)
+	})
+	t.Run("NextPage", func(t *testing.T) {
+		plan := explain(t, readyForInflightJobsNextPageQuery, data.JobQueued, time.Now(), 4, data.PullConsumer,
+			time.Now().Add(-1*time.Hour), xid.New().String())
+		assert.Contains(t, plan, "retry_job", "cursor query should use the retry index; plan was:\n"+plan)
+		assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY", "cursor query should not filesort; plan was:\n"+plan)
+	})
 }
 
 func TestGetJobsForConsumer(t *testing.T) {


### PR DESCRIPTION
## Problem

Query Insights flagged the dispatcher's retry sweep (`GetJobsReadyForInflightSince`) at **1.87s avg / 16.3s p99, 398k calls over 7 days, 199k avg rows scanned to return 12.5**. A sampled plan spent 94.1% of 19.9s in one node — an index range scan reading **190,007 rows to fill a `LIMIT 100`**.

The query filtered on `earliestNextAttemptAt` but ordered by `createdAt DESC, id DESC`. That ordering is free on `job_status_created_id`, so the optimizer picked it to avoid a filesort — but that index doesn't contain `earliestNextAttemptAt`, so every candidate needed a clustered-index row lookup just to read the column and discard the row (~99µs each). Scanning newest-first made it worse: the newest QUEUED jobs are exactly the ones *not yet due*, so each call walked the entire not-due head of the backlog before reaching anything eligible.

`retry_job (status, earliestNextAttemptAt, id, createdAt)` has existed since migration `000003` and is the right index. The optimizer avoided it only because of the `ORDER BY`.

## Fix

Order and keyset-paginate on `earliestNextAttemptAt`, so `retry_job` serves the predicate, the `ORDER BY` and the `LIMIT` in one range seek. **No schema change.**

```sql
SELECT ... FROM job
WHERE status = ? AND earliestNextAttemptAt <= ?
  AND (retryAttemptCount >= ? OR consumerId NOT IN (SELECT id FROM consumer WHERE type = ?))
  AND (earliestNextAttemptAt, id) > (?, ?)      -- continuation only
ORDER BY earliestNextAttemptAt ASC, id ASC LIMIT 100
```

Row-value cursor syntax is deliberate — it stays range-optimizable (MySQL 8.0.14+), whereas `enaa > ? OR (enaa = ? AND id > ?)` degrades to a post-scan filter.

Also:
- Bind `retryThreshold` and consumer type as parameters instead of `fmt.Sprintf`.
- Compute the due-by boundary once per sweep; it was recomputed per page, moving the boundary underneath an advancing cursor.
- Stop on a short page instead of an extra empty round trip.

Oldest-due-first is also the correct order for a retry queue — `createdAt DESC` starved the longest-waiting jobs.

## Verification

`EXPLAIN QUERY PLAN`, old vs new:

```
OLD:  SEARCH job USING INDEX retry_job (status=? AND earliestNextAttemptAt<?)
      USE TEMP B-TREE FOR ORDER BY          <-- the sort MySQL dodges by switching index
NEW:  SEARCH job USING INDEX retry_job (status=? AND (earliestNextAttemptAt,id)>(?,?) AND earliestNextAttemptAt<?)
```

The cursor folds into the seek rather than becoming a filter.

Tests added: a plan regression guard bound to the real query consts (same pattern as the `job_consumer_status_priority` guard), a 120-job multi-page test asserting each job is returned exactly once, an ordering assertion, and an error-path test. `go test ./storage/ ./dispatcher/` passes; the `./config` and root failures are pre-existing on `main` (they read `/proc/sys/kernel/osrelease`, absent on macOS).

## Worth flagging

Unchanged behaviour, but now reachable: the sweep still loads **every** due job into memory before processing any. The slow query was previously self-limiting; a large backlog will now drain fast and could spike memory. Capping or streaming would be a reasonable follow-up — left out to keep this to the query shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
